### PR TITLE
[FEAT] Finishing up Tidal (tests, docs, and some necessary functionality)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,69 @@
 
 Tidal provides internal mechanisms for managing SQL databases in Rotational applications. It provides a migrations mechanism for storing schema versions inside the database and automatically applying schema changes. It also provides a CRUD and Model interface for use with direct SQL statements rather than ORM functionality. Tidal is not meant to be generally used but implements the Rotational SQL pattern.
 
+## Connecting
+
+Use [`tidal.Open`](https://pkg.go.dev/go.rtnl.ai/tidal#Open) to connect to a supported database. Pass a [`*dsn.DSN`](https://pkg.go.dev/go.rtnl.ai/x/dsn#DSN) from `go.rtnl.ai/x/dsn` (typically parsed from `DATABASE_URL`):
+
+```go
+package db
+
+import (
+ "context"
+ "os"
+
+ "go.rtnl.ai/tidal"
+ "go.rtnl.ai/x/dsn"
+)
+
+func Connect(ctx context.Context) (*tidal.DB, error) {
+ uri, err := dsn.Parse(os.Getenv("DATABASE_URL"))
+ if err != nil {
+  return nil, err
+ }
+ return tidal.Open(ctx, uri)
+}
+```
+
+`Open` registers the correct SQL driver, applies custom per-db settings from the DSN parameters, and pings the database before returning. It currently supports SQLite3 and Postgres.
+
+The returned [`*tidal.DB`](https://pkg.go.dev/go.rtnl.ai/tidal#DB) embeds `*sql.DB`, so the usual `Close`, `Ping`, and `ExecContext` methods are available directly. The provider is stored on the connection so transactions bind placeholders automatically.
+
+Start a transaction with [`DB.BeginTx`](https://pkg.go.dev/go.rtnl.ai/tidal#DB.BeginTx). It returns a [`tidal.Tx`](https://pkg.go.dev/go.rtnl.ai/tidal#Tx) that accepts canonical `:name` SQL and `sql.NamedArg` arguments regardless of backend and rewrites them for the backend (ex: Postgres placeholders are rewritten to `$1`, `$2`, etc.).
+
+```go
+import "database/sql"
+
+db, err := tidal.Open(ctx, uri)
+if err != nil {
+ return err
+}
+defer db.Close()
+
+tx, err := db.BeginTx(ctx, nil)
+if err != nil {
+ return err
+}
+defer tx.Rollback()
+
+_, err = tx.Exec(
+ "INSERT INTO users (id, email) VALUES (:id, :email)",
+ sql.Named("id", id),
+ sql.Named("email", email),
+)
+```
+
+Pass `tidal.Tx` to [`CRUD`](https://pkg.go.dev/go.rtnl.ai/tidal#CRUD) methods and [`Rows`](https://pkg.go.dev/go.rtnl.ai/tidal#Rows) cursors.
+
+When you need a raw `*sql.DB` — for migrations, third-party libraries, or admin DDL — use the embedded connection: `db.DB`.
+
+If you already have an open `*sql.DB`, wrap it with [`tidal.Wrap`](https://pkg.go.dev/go.rtnl.ai/tidal#Wrap):
+
+```go
+sqlDB, _ = sql.Open("sqlite3", uri.Path)
+db := tidal.Wrap(sqlDB, uri)
+```
+
 ## Migrations
 
 The `go.rtnl.ai/tidal/migrations` package manages your database schema by tracking which schema version the database is at and automatically applying any newer migrations on startup. Migrations are plain SQL files, embedded into your binary, and applied inside a transaction so that the schema is only advanced when every pending migration succeeds.
@@ -48,10 +111,18 @@ func Migrations() (migrations.Migrations, error) {
 
 ### Applying Migrations
 
-Call `ApplyPostgres` or `ApplySQLite` (depending on your backend) when the database is first connected to. Both methods create the `migrations` bookkeeping table if it does not exist, look up the last applied migration ID, and apply only the migrations whose ID is greater than that. The `version` string you pass is recorded alongside each migration so you can tell which release applied a given schema change.
+Call `ApplyPostgres` or `ApplySQLite` (depending on your backend) after connecting with `tidal.Open`. Both methods create the `migrations` bookkeeping table if it does not exist, look up the last applied migration ID, and apply only the migrations whose ID is greater than that. The `version` string you pass is recorded alongside each migration so you can tell which release applied a given schema change.
+
+Migrations operate on a raw `*sql.DB`; pass `db.DB` from your `*tidal.DB`:
 
 ```go
 ctx := context.Background()
+
+db, err := tidal.Open(ctx, uri)
+if err != nil {
+ return err
+}
+defer db.Close()
 
 m, err := migrations.Load(migrationFS)
 if err != nil {
@@ -59,12 +130,12 @@ if err != nil {
 }
 
 // Postgres: uses an advisory lock so only one instance applies migrations at a time.
-if err := m.ApplyPostgres(ctx, db, "v1.4.0"); err != nil {
+if err := m.ApplyPostgres(ctx, db.DB, "v1.4.0"); err != nil {
  return err
 }
 
 // SQLite: applies all pending migrations in a single write transaction.
-if err := m.ApplySQLite(ctx, db, "v1.4.0"); err != nil {
+if err := m.ApplySQLite(ctx, db.DB, "v1.4.0"); err != nil {
  return err
 }
 ```
@@ -76,7 +147,7 @@ Applying migrations is idempotent: if the database is already up to date, no mig
 Use `LastApplied` to read the most recently applied migration record (ID, name, version, and the time it was applied) from the `migrations` table:
 
 ```go
-last, err := migrations.LastApplied(ctx, db)
+last, err := migrations.LastApplied(ctx, db.DB)
 if err != nil {
  return err
 }

--- a/README.md
+++ b/README.md
@@ -64,12 +64,52 @@ Pass `tidal.Tx` to [`CRUD`](https://pkg.go.dev/go.rtnl.ai/tidal#CRUD) methods an
 
 When you need a raw `*sql.DB` — for migrations, third-party libraries, or admin DDL — use the embedded connection: `db.DB`.
 
-If you already have an open `*sql.DB`, wrap it with [`tidal.Wrap`](https://pkg.go.dev/go.rtnl.ai/tidal#Wrap):
+If you already have an open `*sql.DB`, wrap it with [`tidal.Wrap`](https://pkg.go.dev/go.rtnl.ai/tidal#Wrap). You still need a parsed `*dsn.DSN` so tidal knows which placeholder style to use:
 
 ```go
-sqlDB, _ = sql.Open("sqlite3", uri.Path)
+uri, _ := dsn.Parse(os.Getenv("DATABASE_URL"))
+sqlDB, _ := sql.Open("sqlite3", uri.Path)
 db := tidal.Wrap(sqlDB, uri)
 ```
+
+## CRUD
+
+Implement [`Model`](https://pkg.go.dev/go.rtnl.ai/tidal#Model) on your struct and embed [`BaseModel`](https://pkg.go.dev/go.rtnl.ai/tidal#BaseModel) for ULID ids and timestamps. Build a typed store with [`New`](https://pkg.go.dev/go.rtnl.ai/tidal#New) and run operations inside a transaction:
+
+```go
+crud := tidal.New[*User]("users")
+
+tx, err := db.BeginTx(ctx, nil)
+if err != nil {
+ return err
+}
+defer tx.Rollback()
+
+user := &User{Name: "Ada"}
+_, err = crud.Create(tx, user)
+
+loaded, err := crud.Retrieve(tx, sql.Named("id", user.ID))
+err = crud.Update(tx, user)
+_, err = crud.Delete(tx, sql.Named("id", user.ID))
+
+cursor, err := crud.List(tx, (&tidal.Filter{}).OrderBy("name").Limit(10))
+users, err := cursor.List()
+```
+
+Use [`Clause`](https://pkg.go.dev/go.rtnl.ai/tidal#Clause) for `WHERE` conditions. [`Filter`](https://pkg.go.dev/go.rtnl.ai/tidal#Filter) adds `ORDER BY`, `LIMIT`, and `OFFSET` — combine both when you need filtering and pagination:
+
+```go
+f := (&tidal.Filter{}).OrderBy("-created").Limit(20)
+filter := &tidal.Clause{
+ SQL:  "WHERE status = :status " + f.Clause(),
+ Args: []sql.NamedArg{sql.Named("status", "active")},
+}
+cursor, err := crud.List(tx, filter)
+```
+
+[`Cursor.Close`](https://pkg.go.dev/go.rtnl.ai/tidal#Cursor.Close) rolls back the transaction. Use [`Cursor.CloseRows`](https://pkg.go.dev/go.rtnl.ai/tidal#Cursor.CloseRows) when you want to keep the transaction open for more queries.
+
+See [Fields](#fields) for JSON and array column types.
 
 ## Migrations
 
@@ -86,7 +126,7 @@ migrations/
   0003_add_posts_table.sql
 ```
 
-Migration IDs must be greater than zero, unique, and monotonically increasing, and migration names must be unique. These rules are enforced by `Load` (see `Validate`).
+Migration IDs must be greater than zero, strictly increasing, and migration names must be unique. `Load` enforces these rules via `Validate`.
 
 ### Loading Migrations
 
@@ -111,7 +151,7 @@ func Migrations() (migrations.Migrations, error) {
 
 ### Applying Migrations
 
-Call `ApplyPostgres` or `ApplySQLite` (depending on your backend) after connecting with `tidal.Open`. Both methods create the `migrations` bookkeeping table if it does not exist, look up the last applied migration ID, and apply only the migrations whose ID is greater than that. The `version` string you pass is recorded alongside each migration so you can tell which release applied a given schema change.
+Call `Apply` (or `ApplyPostgres` / `ApplySQLite` directly) after connecting with `tidal.Open`. These methods create the `migrations` bookkeeping table if it does not exist, look up the last applied migration ID, and apply only migrations with a higher ID. The `version` string you pass is recorded alongside each migration so you can tell which release applied a given schema change.
 
 Migrations operate on a raw `*sql.DB`; pass `db.DB` from your `*tidal.DB`:
 
@@ -129,13 +169,8 @@ if err != nil {
  return err
 }
 
-// Postgres: uses an advisory lock so only one instance applies migrations at a time.
-if err := m.ApplyPostgres(ctx, db.DB, "v1.4.0"); err != nil {
- return err
-}
-
-// SQLite: applies all pending migrations in a single write transaction.
-if err := m.ApplySQLite(ctx, db.DB, "v1.4.0"); err != nil {
+// Dispatches to the backend-specific apply method for uri.Provider.
+if err := m.Apply(ctx, uri.Provider, db.DB, "v1.4.0"); err != nil {
  return err
 }
 ```
@@ -309,6 +344,64 @@ if doc.Authors.Valid {
 ```
 
 A zero-value `NullStringArray{}` (or one with `Valid: false`) is written to the database as SQL `NULL`.
+
+## Model conformance (`ConformsCRUD`)
+
+The `go.rtnl.ai/tidal/suite` package includes [`ConformsCRUD`](https://pkg.go.dev/go.rtnl.ai/tidal/suite#ConformsCRUD), a helper that checks a [`Model`](https://pkg.go.dev/go.rtnl.ai/tidal#Model) implementation against [`tidal.CRUD`](https://pkg.go.dev/go.rtnl.ai/tidal#CRUD). Use it in tests to catch `Fields`, `Params`, and `Scan` mistakes before they show up in production.
+
+It runs three subtests:
+
+1. **Shape** — `Fields` and `Params` line up for each operation, and `tidal.New` produced non-empty SQL. No database access.
+2. **Scan** — builds fake row values from `Params`, feeds them through `Scan`, and compares the result to your factory output. No database access.
+3. **RoundTrip** — runs create, retrieve, list, update, and delete against the real database inside a transaction that is always rolled back.
+
+Wire it into a [`DatabaseSuite`](https://pkg.go.dev/go.rtnl.ai/tidal/suite#DatabaseSuite) test (the suite connects, applies migrations, and tears down the database for you):
+
+```go
+package myapp_test
+
+import (
+ "embed"
+ "testing"
+
+ "github.com/stretchr/testify/require"
+ "go.rtnl.ai/tidal/migrations"
+ "go.rtnl.ai/tidal/suite"
+)
+
+//go:embed testdata/migrations
+var migrationFS embed.FS
+
+type ModelTestSuite struct {
+ suite.DatabaseSuite
+}
+
+func TestModels(t *testing.T) {
+ m, err := migrations.Load(migrationFS)
+ require.NoError(t, err)
+
+ s := &ModelTestSuite{}
+ s.Provider = &suite.SQLiteProvider{} // or &suite.PostgresProvider{}
+ s.Migrations = m
+
+ suite.Run(t, s)
+}
+
+func (s *ModelTestSuite) TestUserCRUDConformance() {
+ suite.ConformsCRUD(&s.DatabaseSuite, suite.CRUDConformance[*User]{
+  Table:  "users",
+  Create: newTestUser, // return a fresh row ready to insert
+  Update: func(u *User) {
+   u.Name = "Updated Name" // mutate the inserted row for the update check
+  },
+  Equal: nil // optional model comparison function; if nil uses a good default
+ })
+}
+```
+
+`Create` should return a valid insert each time — generate unique values (email, slug, etc.) inside the factory. `Update` receives the same instance that was created and inserted.
+
+Provide `Equal` when the default comparison is not enough (for example JSON fields that need normalization). Otherwise the suite compares list results on the `Fields(List)` column subset and tolerates database timestamp truncation (compares times to the second).
 
 ## Testing
 

--- a/crud_test.go
+++ b/crud_test.go
@@ -1,0 +1,129 @@
+package tidal_test
+
+import (
+	"database/sql"
+	"fmt"
+
+	"go.rtnl.ai/tidal"
+	"go.rtnl.ai/ulid"
+)
+
+//============================================================================
+// CRUD Error Paths
+//============================================================================
+
+// Update on a row that does not exist must return [tidal.ErrNotFound], not succeed silently.
+func (s *TidalTestSuite) TestUpdateNotFound() {
+	require := s.Require()
+	crud := tidal.New[*User]("users")
+
+	tx := s.BeginTx(nil)
+	defer tx.Rollback()
+
+	user := newConformanceUser()
+	user.Prepare(tidal.Create) // valid ID, but never inserted
+
+	require.ErrorIs(crud.Update(tx, user), tidal.ErrNotFound)
+}
+
+// Validate fails; zero ID returns [tidal.ErrMissingID].
+func (s *TidalTestSuite) TestUpdateValidation() {
+	require := s.Require()
+	crud := tidal.New[*User]("users")
+
+	tx := s.BeginTx(nil)
+	defer tx.Rollback()
+
+	user := &User{Name: "validation-only"}
+	require.ErrorIs(crud.Update(tx, user), tidal.ErrMissingID)
+}
+
+//============================================================================
+// List + Filter
+//============================================================================
+
+// Exercises [tidal.Filter] ORDER BY / LIMIT / OFFSET against a real database.
+// WHERE scoping is supplied via [tidal.Clause] until Filter grows WHERE support.
+func (s *TidalTestSuite) TestListFilter() {
+	require := s.Require()
+	crud := tidal.New[*User]("users")
+
+	tx := s.BeginTx(nil)
+	defer tx.Rollback()
+
+	names := []string{"filter-aaa", "filter-ccc", "filter-bbb"}
+	for _, name := range names {
+		u := newConformanceUser()
+		u.Name = name
+		u.Email = fmt.Sprintf("%s-%s@example.com", name, ulid.MakeSecure().String())
+		_, err := crud.Create(tx, u)
+		require.NoError(err)
+	}
+
+	f := (&tidal.Filter{}).OrderBy("name").Limit(2).Offset(1)
+	filter := &tidal.Clause{
+		SQL:  "WHERE name LIKE :pattern " + f.Clause(),
+		Args: []sql.NamedArg{sql.Named("pattern", "filter-%")},
+	}
+
+	cursor, err := crud.List(tx, filter)
+	require.NoError(err)
+
+	models, err := cursor.List()
+	require.NoError(err)
+	require.NoError(cursor.CloseRows())
+
+	require.Len(models, 2)
+	require.Equal("filter-bbb", models[0].Name)
+	require.Equal("filter-ccc", models[1].Name)
+}
+
+//============================================================================
+// Cursor Lifecycle
+//============================================================================
+
+// [tidal.Cursor.Close] rolls back the transaction.
+func (s *TidalTestSuite) TestCursorCloseRollsBackTx() {
+	require := s.Require()
+
+	tx := s.BeginTx(nil)
+
+	user := &User{}
+	rows, err := tx.Query("SELECT " + joinFields(user.Fields(tidal.List)) + " FROM users LIMIT 1")
+	require.NoError(err)
+
+	cursor := tidal.Rows[*User](tx, rows)
+	require.NoError(cursor.Close())
+
+	_, err = tx.Exec("SELECT 1")
+	require.Error(err, "transaction should be rolled back after cursor.Close")
+}
+
+// [tidal.Cursor.CloseRows] does not roll back the transaction.
+func (s *TidalTestSuite) TestCursorCloseRowsDoesNotRollBackTx() {
+	require := s.Require()
+
+	tx := s.BeginTx(nil)
+
+	user := &User{}
+	rows, err := tx.Query("SELECT " + joinFields(user.Fields(tidal.List)) + " FROM users LIMIT 1")
+	require.NoError(err)
+
+	cursor := tidal.Rows[*User](tx, rows)
+	require.NoError(cursor.CloseRows())
+
+	_, err = tx.Exec("SELECT 1")
+	require.NoError(err)
+}
+
+//============================================================================
+// Test Helpers
+//============================================================================
+
+func joinFields(fields []string) string {
+	out := fields[0]
+	for _, f := range fields[1:] {
+		out += ", " + f
+	}
+	return out
+}

--- a/cursor.go
+++ b/cursor.go
@@ -5,10 +5,27 @@ import "database/sql"
 // Cursor is a generic interface that allows for iteration and instantiation over a
 // collection of models usually from the rows of a database query.
 type Cursor[M Model] interface {
+	// Advances the cursor to the next row; returns false when there are no more
+	// rows.
 	Next() bool
+
+	// Returns the current row as a model instance. It is only valid after
+	// [Cursor.Next] has been called and returned true.
 	Model() (M, error)
+
+	// Reads every remaining row into a slice.
 	List() ([]M, error)
+
+	// Releases the cursor and ends its associated transaction. Use
+	// [Cursor.CloseRows] when you want to reuse the transaction for subsequent
+	// operations.
 	Close() error
+
+	// Releases the result set without ending the transaction. Use this when
+	// the same transaction will run more queries after the cursor is closed.
+	CloseRows() error
+
+	// Returns the first error encountered during iteration.
 	Err() error
 }
 
@@ -52,19 +69,13 @@ func (c *rowsCursor[M]) List() (models []M, err error) {
 	return models, c.Err()
 }
 
-// Closes the underlying result set and rolls back the transaction. Use [CloseRows]
-// when you want to reuse the transaction for subsequent operations.
 func (c *rowsCursor[M]) Close() error {
 	c.tx.Rollback()
 	return c.rows.Close()
 }
 
-// Closes the underlying result set without ending the transaction.
-func CloseRows[M Model](c Cursor[M]) error {
-	if rc, ok := c.(*rowsCursor[M]); ok {
-		return rc.rows.Close()
-	}
-	return nil
+func (c *rowsCursor[M]) CloseRows() error {
+	return c.rows.Close()
 }
 
 func (c *rowsCursor[M]) Err() error {
@@ -75,6 +86,8 @@ func (c *rowsCursor[M]) Err() error {
 // Empty Cursor
 //============================================================================
 
+// Returns a [Cursor] that returns no rows and always returns the provided
+// error, which may be nil.
 func Empty[M Model](err error) Cursor[M] {
 	return &emptyCursor[M]{
 		err: err,
@@ -98,6 +111,10 @@ func (c *emptyCursor[M]) List() ([]M, error) {
 }
 
 func (c *emptyCursor[M]) Close() error {
+	return c.err
+}
+
+func (c *emptyCursor[M]) CloseRows() error {
 	return c.err
 }
 

--- a/cursor.go
+++ b/cursor.go
@@ -52,9 +52,19 @@ func (c *rowsCursor[M]) List() (models []M, err error) {
 	return models, c.Err()
 }
 
+// Closes the underlying result set and rolls back the transaction. Use [CloseRows]
+// when you want to reuse the transaction for subsequent operations.
 func (c *rowsCursor[M]) Close() error {
 	c.tx.Rollback()
 	return c.rows.Close()
+}
+
+// Closes the underlying result set without ending the transaction.
+func CloseRows[M Model](c Cursor[M]) error {
+	if rc, ok := c.(*rowsCursor[M]); ok {
+		return rc.rows.Close()
+	}
+	return nil
 }
 
 func (c *rowsCursor[M]) Err() error {

--- a/cursor.go
+++ b/cursor.go
@@ -33,6 +33,7 @@ type Cursor[M Model] interface {
 // SQL Rows Cursor
 //============================================================================
 
+// Rows wraps [sql.Rows] as a [Cursor] for type M.
 func Rows[M Model](tx Tx, rows *sql.Rows) Cursor[M] {
 	return &rowsCursor[M]{
 		tx:   tx,

--- a/cursor_test.go
+++ b/cursor_test.go
@@ -21,7 +21,7 @@ func (s *TidalTestSuite) TestCursor() {
 	rows, err := tx.Query(fmt.Sprintf("SELECT %s FROM users", fields))
 	require.NoError(err)
 
-	cursor := tidal.Rows[*User](tidal.Wrap(tx), rows)
+	cursor := tidal.Rows[*User](tx, rows)
 	models, err := cursor.List()
 	require.NoError(err)
 	require.Len(models, 25)

--- a/db.go
+++ b/db.go
@@ -1,0 +1,81 @@
+package tidal
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+
+	"go.rtnl.ai/x/dsn"
+
+	_ "github.com/lib/pq"
+	_ "github.com/mattn/go-sqlite3"
+)
+
+// DB is a database connection that knows its provider and returns Tx transactions
+// with automatic :name placeholder rewriting. Use [Open] to connect to a
+// database, or [Wrap] to wrap an existing [sql.DB].
+type DB struct {
+	*sql.DB
+	provider string
+}
+
+// Open connects to the database described by uri.
+func Open(ctx context.Context, uri *dsn.DSN) (*DB, error) {
+	sqlDB, err := open(ctx, uri)
+	if err != nil {
+		return nil, err
+	}
+	return Wrap(sqlDB, uri), nil
+}
+
+// Wraps an existing [sql.DB] with the provider from uri.
+func Wrap(sqlDB *sql.DB, uri *dsn.DSN) *DB {
+	return &DB{
+		DB:       sqlDB,
+		provider: uri.Provider,
+	}
+}
+
+// Provider returns the DSN provider (for example dsn.Postgres or dsn.SQLite3).
+func (db *DB) Provider() string {
+	return db.provider
+}
+
+// BeginTx starts a transaction with automatic placeholder binding for this DB's provider.
+func (db *DB) BeginTx(ctx context.Context, opts *sql.TxOptions) (Tx, error) {
+	tx, err := db.DB.BeginTx(ctx, opts)
+	if err != nil {
+		return nil, err
+	}
+	return newTxn(tx, db.provider), nil
+}
+
+// Opens a new database connection to the database described by uri.
+func open(ctx context.Context, uri *dsn.DSN) (db *sql.DB, err error) {
+	switch uri.Provider {
+	case dsn.SQLite3:
+		if db, err = sql.Open("sqlite3", uri.Path); err != nil {
+			return nil, errors.Join(ErrConnect, err)
+		}
+	case dsn.Postgres:
+		connStr, pgopts, err := dsn.PGConnectionOptions(uri, nil)
+		if err != nil {
+			return nil, errors.Join(ErrConnectionOptions, err)
+		}
+		if db, err = sql.Open("postgres", connStr); err != nil {
+			return nil, errors.Join(ErrConnect, err)
+		}
+		db.SetMaxIdleConns(pgopts.MaxIdleConns)
+		db.SetMaxOpenConns(pgopts.MaxOpenConns)
+		db.SetConnMaxLifetime(pgopts.ConnMaxLifetime)
+		db.SetConnMaxIdleTime(pgopts.ConnMaxIdleTime)
+	default:
+		return nil, &UnsupportedProviderError{Provider: uri.Provider}
+	}
+
+	if err = db.PingContext(ctx); err != nil {
+		_ = db.Close()
+		return nil, errors.Join(ErrPing, err)
+	}
+	return db, nil
+}

--- a/db_test.go
+++ b/db_test.go
@@ -1,0 +1,20 @@
+package tidal_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.rtnl.ai/tidal"
+	"go.rtnl.ai/x/dsn"
+)
+
+// Tests that [tidal.Open] returns an error when given an unsupported provider.
+func TestOpenUnsupportedProvider(t *testing.T) {
+	_, err := tidal.Open(context.Background(), &dsn.DSN{Provider: "mysql"})
+	require.Error(t, err)
+
+	var unsupported *tidal.UnsupportedProviderError
+	require.ErrorAs(t, err, &unsupported)
+	require.Equal(t, "mysql", unsupported.Provider)
+}

--- a/doc.go
+++ b/doc.go
@@ -1,0 +1,9 @@
+// Package tidal connects to SQL databases and runs typed CRUD queries without an ORM.
+//
+// Open a connection with [Open], start a transaction with [DB.BeginTx], and pass the
+// transaction to [CRUD] methods from [New]. Write SQL with :name placeholders; tidal
+// rewrites them for Postgres ($1, $2, …) or SQLite (?).
+//
+// Implement [Model] on your structs and embed [BaseModel] for IDs and timestamps.
+// Use [ListFilter] ([Filter] or [Clause]) to sort and paginate list queries.
+package tidal

--- a/errors.go
+++ b/errors.go
@@ -1,8 +1,39 @@
 package tidal
 
-import "errors"
+import (
+	"errors"
+	"fmt"
+)
 
 var (
+	// Constraint errors
+
 	ErrMissingID = errors.New("missing ID")
 	ErrNotFound  = errors.New("not found")
+
+	// Connection errors
+
+	ErrUnsupportedPlaceholder = errors.New("unsupported placeholder type")
+	ErrConnectionOptions      = errors.New("could not get connection options")
+	ErrConnect                = errors.New("could not connect to database")
+	ErrPing                   = errors.New("could not ping database")
 )
+
+// UnsupportedProviderError is returned when [Open] is called with a DSN provider
+// that tidal does not support.
+type UnsupportedProviderError struct {
+	Provider string
+}
+
+func (e *UnsupportedProviderError) Error() string {
+	return fmt.Sprintf("unsupported database provider: %q", e.Provider)
+}
+
+// MissingArgumentError is returned when a :name placeholder has no matching [sql.NamedArg].
+type MissingArgumentError struct {
+	Name string
+}
+
+func (e *MissingArgumentError) Error() string {
+	return fmt.Sprintf("missing argument %q for query", e.Name)
+}

--- a/fields/doc.go
+++ b/fields/doc.go
@@ -1,0 +1,7 @@
+// Package fields provides column types for JSON and string arrays.
+//
+// Use them as fields on [tidal.Model] structs. They implement [database/sql.Scanner]
+// and [database/sql/driver.Valuer], so [tidal.CRUD] queries read and write them
+// without extra conversion code. Backing columns should store JSON (JSONB, BYTEA,
+// BLOB, or TEXT depending on your database).
+package fields

--- a/fields/jsonb.go
+++ b/fields/jsonb.go
@@ -8,13 +8,16 @@ import (
 	"slices"
 )
 
+// JSONB stores raw JSON in a NOT NULL column. SQL NULL and JSON "null" scan as nil.
 type JSONB json.RawMessage
 
+// NullJSONB stores JSON in a nullable column. Check Valid after scanning.
 type NullJSONB struct {
 	Valid bool
 	JSONB JSONB
 }
 
+// JSONNull is the JSON literal null as bytes.
 var JSONNull = []byte("null")
 
 //============================================================================
@@ -49,6 +52,7 @@ func (j JSONB) Normalize() []byte {
 // JSONB Methods
 //============================================================================
 
+// Scan implements [database/sql.Scanner].
 func (j *JSONB) Scan(src any) error {
 	if src == nil {
 		*j = nil
@@ -71,6 +75,7 @@ func (j *JSONB) Scan(src any) error {
 	return nil
 }
 
+// Value implements [database/sql/driver.Valuer].
 func (j JSONB) Value() (driver.Value, error) {
 	if len(j) == 0 {
 		return nil, nil
@@ -78,10 +83,12 @@ func (j JSONB) Value() (driver.Value, error) {
 	return []byte(j), nil
 }
 
+// IsNull reports whether the value is empty or the JSON literal null.
 func (j JSONB) IsNull() bool {
 	return len(j) == 0 || bytes.Equal(j, JSONNull)
 }
 
+// UnmarshalTo decodes the JSON into dst. A nil or empty value is a no-op.
 func (j JSONB) UnmarshalTo(dst any) error {
 	if len(j) == 0 {
 		return nil
@@ -89,6 +96,7 @@ func (j JSONB) UnmarshalTo(dst any) error {
 	return json.Unmarshal(j, dst)
 }
 
+// MarshalFrom JSON-encodes src into the field. A nil src clears the field.
 func (j *JSONB) MarshalFrom(src any) (err error) {
 	if src == nil {
 		*j = nil
@@ -108,6 +116,7 @@ func (j *JSONB) MarshalFrom(src any) (err error) {
 // NullJSONB Methods
 //============================================================================
 
+// Scan implements [database/sql.Scanner].
 func (n *NullJSONB) Scan(src any) (err error) {
 	if src == nil {
 		n.JSONB, n.Valid = nil, false
@@ -123,6 +132,7 @@ func (n *NullJSONB) Scan(src any) (err error) {
 	return nil
 }
 
+// Value implements [database/sql/driver.Valuer].
 func (n NullJSONB) Value() (driver.Value, error) {
 	if !n.Valid {
 		return nil, nil
@@ -130,6 +140,7 @@ func (n NullJSONB) Value() (driver.Value, error) {
 	return n.JSONB.Value()
 }
 
+// UnmarshalTo decodes the JSON when Valid is true.
 func (j NullJSONB) UnmarshalTo(dst any) error {
 	if !j.Valid {
 		return nil
@@ -137,6 +148,7 @@ func (j NullJSONB) UnmarshalTo(dst any) error {
 	return j.JSONB.UnmarshalTo(dst)
 }
 
+// MarshalFrom JSON-encodes src and sets Valid. Nil or JSON null becomes SQL NULL.
 func (j *NullJSONB) MarshalFrom(src any) (err error) {
 	if err = j.JSONB.MarshalFrom(src); err != nil {
 		j.Valid = false

--- a/fields/jsonb_test.go
+++ b/fields/jsonb_test.go
@@ -45,7 +45,7 @@ func (s *FieldsSqliteTestSuite) TestJSONB() {
 		defer tx.Rollback()
 
 		// Insert a new record into the database.
-		params := []any{
+		params := []sql.NamedArg{
 			sql.Named("alpha", JSONB(alphaBytes)),
 			sql.Named("bravo", JSONB(bravoBytes)),
 		}
@@ -93,7 +93,7 @@ func (s *FieldsSqliteTestSuite) TestJSONB() {
 		defer tx.Rollback()
 
 		// Insert a new record into the database.
-		params := []any{
+		params := []sql.NamedArg{
 			sql.Named("alpha", `{}`),
 			sql.Named("bravo", nil),
 		}
@@ -120,21 +120,21 @@ func (s *FieldsPostgresTestSuite) TestJSONB() {
 		tx := s.BeginTx(nil)
 		defer tx.Rollback()
 
-		params := []any{
+		params := []sql.NamedArg{
 			sql.Named("alpha", JSONB(alphaBytes)),
 			sql.Named("bravo", JSONB(bravoBytes)),
 			sql.Named("charlie", JSONB(charlieBytes)),
 			sql.Named("delta", JSONB(deltaBytes)),
 		}
 
-		ins := tx.QueryRow("INSERT INTO testing (alpha, bravo, charlie, delta) VALUES ($1, $2, $3, $4) RETURNING id", params...)
+		ins := tx.QueryRow("INSERT INTO testing (alpha, bravo, charlie, delta) VALUES (:alpha, :bravo, :charlie, :delta) RETURNING id", params...)
 
 		var id int64
 		require.NoError(ins.Scan(&id), "could not insert record or scan ID")
 		require.NotZero(id, "expected last insert id to be non-zero")
 
 		// Fetch the record from the database.
-		row := tx.QueryRow("SELECT alpha, bravo, charlie, delta FROM testing WHERE id=$1", id)
+		row := tx.QueryRow("SELECT alpha, bravo, charlie, delta FROM testing WHERE id=:id", sql.Named("id", id))
 
 		var alpha, bravo, charlie, delta JSONB
 		require.NoError(row.Scan(&alpha, &bravo, &charlie, &delta), "could not scan record")
@@ -157,7 +157,7 @@ func (s *FieldsPostgresTestSuite) TestJSONB() {
 		require.NotZero(id, "expected last insert id to be non-zero")
 
 		// Fetch the record from the database.
-		row := tx.QueryRow("SELECT alpha, bravo, charlie, delta FROM testing WHERE id=$1", id)
+		row := tx.QueryRow("SELECT alpha, bravo, charlie, delta FROM testing WHERE id=:id", sql.Named("id", id))
 
 		var alpha, bravo, charlie, delta JSONB
 		require.NoError(row.Scan(&alpha, &bravo, &charlie, &delta), "could not scan record")
@@ -172,18 +172,18 @@ func (s *FieldsPostgresTestSuite) TestJSONB() {
 		tx := s.BeginTx(nil)
 		defer tx.Rollback()
 
-		params := []any{
+		params := []sql.NamedArg{
 			sql.Named("bravo", nil),
 			sql.Named("delta", nil),
 		}
-		ins := tx.QueryRow("INSERT INTO testing (alpha, bravo, charlie, delta) VALUES ('{}', $1, '{}', $2) RETURNING id", params...)
+		ins := tx.QueryRow("INSERT INTO testing (alpha, bravo, charlie, delta) VALUES ('{}', :bravo, '{}', :delta) RETURNING id", params...)
 
 		var id int64
 		require.NoError(ins.Scan(&id), "could not scan record")
 		require.NotZero(id, "expected last insert id to be non-zero")
 
 		// Fetch the record from the database.
-		row := tx.QueryRow("SELECT alpha, bravo, charlie, delta FROM testing WHERE id=$1", id)
+		row := tx.QueryRow("SELECT alpha, bravo, charlie, delta FROM testing WHERE id=:id", sql.Named("id", id))
 
 		var alpha, bravo, charlie, delta JSONB
 		require.NoError(row.Scan(&alpha, &bravo, &charlie, &delta), "could not scan record")
@@ -270,7 +270,7 @@ func (s *FieldsSqliteTestSuite) TestNullJSONB() {
 		tx := s.BeginTx(nil)
 		defer tx.Rollback()
 
-		params := []any{
+		params := []sql.NamedArg{
 			sql.Named("alpha", NullJSONB{JSONB: JSONB(alphaBytes), Valid: true}),
 			sql.Named("bravo", NullJSONB{JSONB: JSONB(bravoBytes), Valid: true}),
 		}
@@ -319,20 +319,20 @@ func (s *FieldsPostgresTestSuite) TestNullJSONB() {
 		tx := s.BeginTx(nil)
 		defer tx.Rollback()
 
-		params := []any{
+		params := []sql.NamedArg{
 			sql.Named("alpha", NullJSONB{JSONB: JSONB(alphaBytes), Valid: true}),
 			sql.Named("bravo", NullJSONB{JSONB: JSONB(bravoBytes), Valid: true}),
 			sql.Named("charlie", NullJSONB{JSONB: JSONB(charlieBytes), Valid: true}),
 			sql.Named("delta", NullJSONB{JSONB: JSONB(deltaBytes), Valid: true}),
 		}
-		ins := tx.QueryRow("INSERT INTO testing (alpha, bravo, charlie, delta) VALUES ($1, $2, $3, $4) RETURNING id", params...)
+		ins := tx.QueryRow("INSERT INTO testing (alpha, bravo, charlie, delta) VALUES (:alpha, :bravo, :charlie, :delta) RETURNING id", params...)
 
 		var id int64
 		require.NoError(ins.Scan(&id), "could not insert record or scan ID")
 		require.NotZero(id, "expected last insert id to be non-zero")
 
 		// Fetch the record from the database.
-		row := tx.QueryRow("SELECT alpha, bravo, charlie, delta FROM testing WHERE id=$1", id)
+		row := tx.QueryRow("SELECT alpha, bravo, charlie, delta FROM testing WHERE id=:id", sql.Named("id", id))
 
 		var alpha, bravo, charlie, delta NullJSONB
 		require.NoError(row.Scan(&alpha, &bravo, &charlie, &delta), "could not scan record")
@@ -360,7 +360,7 @@ func (s *FieldsPostgresTestSuite) TestNullJSONB() {
 		require.NotZero(id, "expected last insert id to be non-zero")
 
 		// Fetch the record from the database.
-		row := tx.QueryRow("SELECT alpha, bravo, charlie, delta FROM testing WHERE id=$1", id)
+		row := tx.QueryRow("SELECT alpha, bravo, charlie, delta FROM testing WHERE id=:id", sql.Named("id", id))
 
 		var alpha, bravo, charlie, delta NullJSONB
 		require.NoError(row.Scan(&alpha, &bravo, &charlie, &delta), "could not scan record")

--- a/fields/text.go
+++ b/fields/text.go
@@ -6,8 +6,10 @@ import (
 	"fmt"
 )
 
+// StringArray stores a list of strings as a JSON array in a NOT NULL column.
 type StringArray []string
 
+// NullStringArray stores a list of strings in a nullable column. Check Valid after scanning.
 type NullStringArray struct {
 	Valid       bool
 	StringArray StringArray
@@ -17,6 +19,7 @@ type NullStringArray struct {
 // StringArray Methods
 //============================================================================
 
+// Scan implements [database/sql.Scanner].
 func (s *StringArray) Scan(src any) (err error) {
 	if src == nil {
 		*s = nil
@@ -39,6 +42,7 @@ func (s *StringArray) Scan(src any) (err error) {
 	return nil
 }
 
+// Value implements [database/sql/driver.Valuer].
 func (s StringArray) Value() (driver.Value, error) {
 	if len(s) == 0 {
 		return nil, nil
@@ -50,6 +54,7 @@ func (s StringArray) Value() (driver.Value, error) {
 // NullStringArray Methods
 //============================================================================
 
+// Scan implements [database/sql.Scanner].
 func (n *NullStringArray) Scan(src any) (err error) {
 	if src == nil {
 		n.StringArray, n.Valid = nil, false
@@ -65,6 +70,7 @@ func (n *NullStringArray) Scan(src any) (err error) {
 	return nil
 }
 
+// Value implements [database/sql/driver.Valuer].
 func (n NullStringArray) Value() (driver.Value, error) {
 	if !n.Valid {
 		return nil, nil

--- a/fields/text_test.go
+++ b/fields/text_test.go
@@ -18,7 +18,7 @@ func (s *FieldsSqliteTestSuite) TestStringArray() {
 		tx := s.BeginTx(nil)
 		defer tx.Rollback()
 
-		params := []any{
+		params := []sql.NamedArg{
 			sql.Named("alpha", alpha),
 			sql.Named("bravo", bravo),
 		}
@@ -64,7 +64,7 @@ func (s *FieldsSqliteTestSuite) TestStringArray() {
 		defer tx.Rollback()
 
 		// Insert a new record into the database.
-		params := []any{
+		params := []sql.NamedArg{
 			sql.Named("alpha", `[]`),
 			sql.Named("bravo", nil),
 		}
@@ -98,21 +98,21 @@ func (s *FieldsPostgresTestSuite) TestStringArray() {
 		tx := s.BeginTx(nil)
 		defer tx.Rollback()
 
-		params := []any{
+		params := []sql.NamedArg{
 			sql.Named("alpha", alpha),
 			sql.Named("bravo", bravo),
 			sql.Named("charlie", charlie),
 			sql.Named("delta", delta),
 		}
 
-		row := tx.QueryRow("INSERT INTO testing (alpha, bravo, charlie, delta) VALUES ($1, $2, $3, $4) RETURNING id", params...)
+		row := tx.QueryRow("INSERT INTO testing (alpha, bravo, charlie, delta) VALUES (:alpha, :bravo, :charlie, :delta) RETURNING id", params...)
 
 		var id int64
 		require.NoError(row.Scan(&id), "could not scan record")
 		require.NotZero(id, "expected last insert id to be non-zero")
 
 		// Fetch the record from the database.
-		row = tx.QueryRow("SELECT alpha, bravo, charlie, delta FROM testing WHERE id=$1", id)
+		row = tx.QueryRow("SELECT alpha, bravo, charlie, delta FROM testing WHERE id=:id", sql.Named("id", id))
 
 		var aOut, bOut, cOut, dOut StringArray
 		require.NoError(row.Scan(&aOut, &bOut, &cOut, &dOut), "could not scan record")
@@ -135,7 +135,7 @@ func (s *FieldsPostgresTestSuite) TestStringArray() {
 		require.NotZero(id, "expected last insert id to be non-zero")
 
 		// Fetch the record from the database.
-		row = tx.QueryRow("SELECT alpha, bravo, charlie, delta FROM testing WHERE id=$1", id)
+		row = tx.QueryRow("SELECT alpha, bravo, charlie, delta FROM testing WHERE id=:id", sql.Named("id", id))
 
 		var aOut, bOut, cOut, dOut StringArray
 		require.NoError(row.Scan(&aOut, &bOut, &cOut, &dOut), "could not scan record")
@@ -151,20 +151,20 @@ func (s *FieldsPostgresTestSuite) TestStringArray() {
 		tx := s.BeginTx(nil)
 		defer tx.Rollback()
 
-		params := []any{
+		params := []sql.NamedArg{
 			sql.Named("alpha", `[]`),
 			sql.Named("bravo", nil),
 			sql.Named("charlie", `[]`),
 			sql.Named("delta", nil),
 		}
-		row := tx.QueryRow("INSERT INTO testing (alpha, bravo, charlie, delta) VALUES ($1, $2, $3, $4) RETURNING id", params...)
+		row := tx.QueryRow("INSERT INTO testing (alpha, bravo, charlie, delta) VALUES (:alpha, :bravo, :charlie, :delta) RETURNING id", params...)
 
 		var id int64
 		require.NoError(row.Scan(&id), "could not scan record")
 		require.NotZero(id, "expected last insert id to be non-zero")
 
 		// Fetch the record from the database.
-		row = tx.QueryRow("SELECT alpha, bravo, charlie, delta FROM testing WHERE id=$1", id)
+		row = tx.QueryRow("SELECT alpha, bravo, charlie, delta FROM testing WHERE id=:id", sql.Named("id", id))
 
 		var aOut, bOut, cOut, dOut StringArray
 		require.NoError(row.Scan(&aOut, &bOut, &cOut, &dOut), "could not scan record")
@@ -187,7 +187,7 @@ func (s *FieldsSqliteTestSuite) TestNullStringArray() {
 		tx := s.BeginTx(nil)
 		defer tx.Rollback()
 
-		params := []any{
+		params := []sql.NamedArg{
 			sql.Named("alpha", alpha),
 			sql.Named("bravo", bravo),
 		}
@@ -243,20 +243,20 @@ func (s *FieldsPostgresTestSuite) TestNullStringArray() {
 		tx := s.BeginTx(nil)
 		defer tx.Rollback()
 
-		params := []any{
+		params := []sql.NamedArg{
 			sql.Named("alpha", alpha),
 			sql.Named("bravo", bravo),
 			sql.Named("charlie", charlie),
 			sql.Named("delta", delta),
 		}
-		row := tx.QueryRow("INSERT INTO testing (alpha, bravo, charlie, delta) VALUES ($1, $2, $3, $4) RETURNING id", params...)
+		row := tx.QueryRow("INSERT INTO testing (alpha, bravo, charlie, delta) VALUES (:alpha, :bravo, :charlie, :delta) RETURNING id", params...)
 
 		var id int64
 		require.NoError(row.Scan(&id), "could not scan record")
 		require.NotZero(id, "expected last insert id to be non-zero")
 
 		// Fetch the record from the database.
-		row = tx.QueryRow("SELECT alpha, bravo, charlie, delta FROM testing WHERE id=$1", id)
+		row = tx.QueryRow("SELECT alpha, bravo, charlie, delta FROM testing WHERE id=:id", sql.Named("id", id))
 
 		var aOut, bOut, cOut, dOut NullStringArray
 		require.NoError(row.Scan(&aOut, &bOut, &cOut, &dOut), "could not scan record")
@@ -276,18 +276,18 @@ func (s *FieldsPostgresTestSuite) TestNullStringArray() {
 		tx := s.BeginTx(nil)
 		defer tx.Rollback()
 
-		params := []any{
+		params := []sql.NamedArg{
 			sql.Named("bravo", NullStringArray{Valid: false}),
 			sql.Named("delta", NullStringArray{Valid: false}),
 		}
 
-		row := tx.QueryRow("INSERT INTO testing (alpha, bravo, charlie, delta) VALUES ('[]', $1, '[]', $2) RETURNING id", params...)
+		row := tx.QueryRow("INSERT INTO testing (alpha, bravo, charlie, delta) VALUES ('[]', :bravo, '[]', :delta) RETURNING id", params...)
 
 		var id int64
 		require.NoError(row.Scan(&id), "could not scan record")
 		require.NotZero(id, "expected last insert id to be non-zero")
 
-		row = tx.QueryRow("SELECT alpha, bravo, charlie, delta FROM testing WHERE id=$1", id)
+		row = tx.QueryRow("SELECT alpha, bravo, charlie, delta FROM testing WHERE id=:id", sql.Named("id", id))
 
 		var aOut, bOut, cOut, dOut NullStringArray
 		require.NoError(row.Scan(&aOut, &bOut, &cOut, &dOut), "could not scan record")

--- a/filter.go
+++ b/filter.go
@@ -131,6 +131,7 @@ func (f *Filter) Params() []sql.NamedArg {
 // Ordering
 //============================================================================
 
+// Ordering is a list of sort columns rendered as an ORDER BY clause.
 type Ordering []OrderBy
 
 func (o Ordering) String() string {
@@ -145,6 +146,7 @@ func (o Ordering) String() string {
 	return sb.String()
 }
 
+// OrderBy is one column and sort direction in an [Ordering].
 type OrderBy struct {
 	field     string
 	direction OrderDirection
@@ -154,6 +156,7 @@ func (o OrderBy) String() string {
 	return fmt.Sprintf("%s %s", o.field, o.direction)
 }
 
+// OrderDirection is ASC or DESC in an [OrderBy].
 type OrderDirection uint8
 
 const (
@@ -176,8 +179,10 @@ func (o OrderDirection) String() string {
 // Limit and Offset
 //============================================================================
 
+// Limit is a row cap rendered as a LIMIT clause.
 type Limit int
 
+// Offset is a row skip rendered as an OFFSET clause.
 type Offset int
 
 func (s Limit) String() string {

--- a/filter.go
+++ b/filter.go
@@ -19,7 +19,6 @@ type ListFilter interface {
 
 // Clause is a manual filtering mechanism that implements the ListFilter interface, but
 // requires the user to manually construct the SQL clause and parameters.
-// TODO: Add Tests for this
 type Clause struct {
 	SQL  string
 	Args []sql.NamedArg
@@ -39,7 +38,6 @@ func (c *Clause) Params() []sql.NamedArg {
 // returned and that the parameters in the query are in the correct order.
 //
 // TODO: Handle WHERE clauses.
-// TODO: Add Tests for this.
 type Filter struct {
 	limit    *Limit
 	offset   *Offset

--- a/filter_test.go
+++ b/filter_test.go
@@ -1,0 +1,38 @@
+package tidal
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+//============================================================================
+// Filter Clause Builder
+//============================================================================
+
+// Verifies [Filter.Clause] produces correct ANSI SQL for ordering, pagination, and
+// fluent-builder overwrite/clear semantics. No database required.
+func TestFilterClause(t *testing.T) {
+	t.Run("OrderByAscDesc", func(t *testing.T) {
+		// Bare column is ASC; -prefix is DESC.
+		f := (&Filter{}).OrderBy("name", "-created")
+		require.Equal(t, "ORDER BY name ASC, created DESC", f.Clause())
+	})
+
+	t.Run("LimitOffset", func(t *testing.T) {
+		f := (&Filter{}).OrderBy("id").Limit(10).Offset(5)
+		require.Equal(t, "ORDER BY id ASC LIMIT 10 OFFSET 5", f.Clause())
+	})
+
+	t.Run("ClearLimitOffset", func(t *testing.T) {
+		// n=-1 clears a previously set limit or offset.
+		f := (&Filter{}).Limit(10).Offset(5).Limit(-1).Offset(-1)
+		require.Empty(t, f.Clause())
+	})
+
+	t.Run("OrderByOverwrite", func(t *testing.T) {
+		// Each OrderBy call replaces the previous ordering entirely.
+		f := (&Filter{}).OrderBy("name").OrderBy("-email")
+		require.Equal(t, "ORDER BY email DESC", f.Clause())
+	})
+}

--- a/migrations/doc.go
+++ b/migrations/doc.go
@@ -1,0 +1,8 @@
+// Package migrations loads versioned SQL files from an [io/fs.FS] and applies any
+// that have not been run yet.
+//
+// Name files NNNN_description.sql (for example 0001_initial_schema.sql), embed them
+// with //go:embed, load with [Load], then call [Migrations.ApplyPostgres],
+// [Migrations.ApplySQLite], or [Migrations.Apply] after connecting. Pass your app
+// version string so each applied migration is recorded with the release that ran it.
+package migrations

--- a/migrations/migrations.go
+++ b/migrations/migrations.go
@@ -20,12 +20,23 @@ import (
 )
 
 var (
-	ErrNoMigrations     = errors.New("no migrations found")
+	// ErrNoMigrations is returned when [Load] finds no migration files.
+	ErrNoMigrations = errors.New("no migrations found")
+
+	// ErrUnboundMigration is returned when [Migration.SQL] is called without a file system.
 	ErrUnboundMigration = errors.New("migration has been instantiated incorrectly without an underlying fs.FS")
-	ErrInvalidID        = errors.New("migration IDs must be greater than 0")
-	ErrDuplicateID      = errors.New("duplicate migration IDs detected")
-	ErrDuplicateName    = errors.New("duplicate migration names detected")
-	ErrInvalidSequence  = errors.New("migration IDs must be monotonically increasing")
+
+	// ErrInvalidID is returned when a migration ID is zero or negative.
+	ErrInvalidID = errors.New("migration IDs must be greater than 0")
+
+	// ErrDuplicateID is returned when two migrations share the same ID.
+	ErrDuplicateID = errors.New("duplicate migration IDs detected")
+
+	// ErrDuplicateName is returned when two migrations share the same name.
+	ErrDuplicateName = errors.New("duplicate migration names detected")
+
+	// ErrInvalidSequence is returned when migration IDs are not strictly increasing.
+	ErrInvalidSequence = errors.New("migration IDs must be monotonically increasing")
 )
 
 // Process migration file names
@@ -101,8 +112,10 @@ func Load(files fs.FS) (migrations Migrations, err error) {
 	return migrations, nil
 }
 
+// Migrations is an ordered list of schema migrations to apply.
 type Migrations []*Migration
 
+// Apply runs pending migrations using the backend-specific method for provider.
 func (m Migrations) Apply(ctx context.Context, provider string, db *sql.DB, version string) error {
 	// Sort the migrations by ID
 	m.Sort()
@@ -151,6 +164,7 @@ func (m Migrations) Validate() error {
 	return nil
 }
 
+// Sort orders migrations by ID ascending.
 func (m Migrations) Sort() {
 	slices.SortFunc(m, func(a, b *Migration) int {
 		return cmp.Compare(a.ID, b.ID)
@@ -216,6 +230,7 @@ func (m *Migration) SQL() (_ string, err error) {
 	return string(bytes.TrimSpace(data)), nil
 }
 
+// WithFS attaches a file system so [Migration.SQL] can read the migration file.
 func (m *Migration) WithFS(fs fs.FS) {
 	m.fs = fs
 }

--- a/migrations/postgres.go
+++ b/migrations/postgres.go
@@ -29,6 +29,7 @@ const (
 	acquireMigrationLockSQL = `SELECT pg_advisory_lock($1);`
 	releaseMigrationLockSQL = `SELECT pg_advisory_unlock($1);`
 
+	// AdvisoryLockID is the Postgres advisory lock used by [Migrations.ApplyPostgres].
 	AdvisoryLockID = int64(4006367007158143198)
 )
 

--- a/migrations/postgres_test.go
+++ b/migrations/postgres_test.go
@@ -28,10 +28,10 @@ func (s *PostgresTestSuite) TestMigrations() {
 	require.NoError(err)
 	require.NotNil(migrations)
 
-	err = migrations.ApplyPostgres(context.Background(), s.DB, "v1.0.0")
+	err = migrations.ApplyPostgres(context.Background(), s.DB.DB, "v1.0.0")
 	require.NoError(err)
 
-	last, err := LastApplied(context.Background(), s.DB)
+	last, err := LastApplied(context.Background(), s.DB.DB)
 	require.NoError(err)
 	require.NotNil(last)
 	require.Equal(3, last.ID)
@@ -51,28 +51,28 @@ func (s *PostgresTestSuite) TestApplyOrdered() {
 	charlie := migrations[2:]
 
 	require.Len(alpha, 1, "expected 1 migration")
-	err = alpha.ApplyPostgres(context.Background(), s.DB, "v1.0.0")
+	err = alpha.ApplyPostgres(context.Background(), s.DB.DB, "v1.0.0")
 	require.NoError(err)
 
-	last, err := LastApplied(context.Background(), s.DB)
+	last, err := LastApplied(context.Background(), s.DB.DB)
 	require.NoError(err)
 	require.Equal(1, last.ID)
 	require.Equal("v1.0.0", last.Version)
 
 	require.Len(bravo, 1, "expected 1 migration")
-	err = bravo.ApplyPostgres(context.Background(), s.DB, "v1.1.0")
+	err = bravo.ApplyPostgres(context.Background(), s.DB.DB, "v1.1.0")
 	require.NoError(err)
 
-	last, err = LastApplied(context.Background(), s.DB)
+	last, err = LastApplied(context.Background(), s.DB.DB)
 	require.NoError(err)
 	require.Equal(2, last.ID)
 	require.Equal("v1.1.0", last.Version)
 
 	require.Len(charlie, 1, "expected 1 migration")
-	err = charlie.ApplyPostgres(context.Background(), s.DB, "v1.2.0")
+	err = charlie.ApplyPostgres(context.Background(), s.DB.DB, "v1.2.0")
 	require.NoError(err)
 
-	last, err = LastApplied(context.Background(), s.DB)
+	last, err = LastApplied(context.Background(), s.DB.DB)
 	require.NoError(err)
 	require.Equal(3, last.ID)
 	require.Equal("v1.2.0", last.Version)

--- a/migrations/sqlite_test.go
+++ b/migrations/sqlite_test.go
@@ -28,10 +28,10 @@ func (s *SQLiteTestSuite) TestMigrations() {
 	require.NoError(err)
 	require.NotNil(migrations)
 
-	err = migrations.ApplySQLite(context.Background(), s.DB, "v1.0.0")
+	err = migrations.ApplySQLite(context.Background(), s.DB.DB, "v1.0.0")
 	require.NoError(err)
 
-	last, err := LastApplied(context.Background(), s.DB)
+	last, err := LastApplied(context.Background(), s.DB.DB)
 	require.NoError(err)
 	require.NotNil(last)
 	require.Equal(3, last.ID)
@@ -51,28 +51,28 @@ func (s *SQLiteTestSuite) TestApplyOrdered() {
 	charlie := migrations[2:]
 
 	require.Len(alpha, 1, "expected 1 migration")
-	err = alpha.ApplySQLite(context.Background(), s.DB, "v1.0.0")
+	err = alpha.ApplySQLite(context.Background(), s.DB.DB, "v1.0.0")
 	require.NoError(err)
 
-	last, err := LastApplied(context.Background(), s.DB)
+	last, err := LastApplied(context.Background(), s.DB.DB)
 	require.NoError(err)
 	require.Equal(1, last.ID)
 	require.Equal("v1.0.0", last.Version)
 
 	require.Len(bravo, 1, "expected 1 migration")
-	err = bravo.ApplySQLite(context.Background(), s.DB, "v1.1.0")
+	err = bravo.ApplySQLite(context.Background(), s.DB.DB, "v1.1.0")
 	require.NoError(err)
 
-	last, err = LastApplied(context.Background(), s.DB)
+	last, err = LastApplied(context.Background(), s.DB.DB)
 	require.NoError(err)
 	require.Equal(2, last.ID)
 	require.Equal("v1.1.0", last.Version)
 
 	require.Len(charlie, 1, "expected 1 migration")
-	err = charlie.ApplySQLite(context.Background(), s.DB, "v1.2.0")
+	err = charlie.ApplySQLite(context.Background(), s.DB.DB, "v1.2.0")
 	require.NoError(err)
 
-	last, err = LastApplied(context.Background(), s.DB)
+	last, err = LastApplied(context.Background(), s.DB.DB)
 	require.NoError(err)
 	require.Equal(3, last.ID)
 	require.Equal("v1.2.0", last.Version)

--- a/models.go
+++ b/models.go
@@ -55,6 +55,7 @@ type Validator interface {
 // Model Factory
 //============================================================================
 
+// Make returns a new zero value of M, allocating a pointer when M is a pointer type.
 func Make[M Model]() M {
 	var instance M
 
@@ -106,6 +107,7 @@ func (b *BaseModel) Validate(op Operation) error {
 	return nil
 }
 
+// IsZero reports whether the receiver is nil or all fields are zero.
 func (b *BaseModel) IsZero() bool {
 	return b == nil || (b.ID.IsZero() && b.Created.IsZero() && b.Modified.IsZero())
 }

--- a/models.go
+++ b/models.go
@@ -29,8 +29,9 @@ type Model interface {
 	Params(Operation) []sql.NamedArg
 }
 
-// Scanner is an interface for *sql.Rows and *sql.Row so that models can implement how
-// they scan fields into their struct without having to specify every field every time.
+// Scanner is an interface for [*Row], [*sql.Row], and [*sql.Rows] so that models can
+// implement how they scan fields into their struct without having to specify every
+// field every time.
 type Scanner interface {
 	Scan(dest ...any) error
 }

--- a/operation.go
+++ b/operation.go
@@ -1,5 +1,6 @@
 package tidal
 
+// Operation identifies which CRUD step a [Model] method is serving.
 type Operation uint8
 
 const (
@@ -11,11 +12,14 @@ const (
 	Delete
 )
 
-var (
-	SelectOperations  = [2]Operation{List, Retrieve}
-	EditOperations    = [3]Operation{Create, Update, Delete}
-	PrepareOperations = [2]Operation{Create, Update}
-)
+// SelectOperations lists read-only [Operation] values.
+var SelectOperations = [2]Operation{List, Retrieve}
+
+// EditOperations lists write [Operation] values.
+var EditOperations = [3]Operation{Create, Update, Delete}
+
+// PrepareOperations lists [Operation] values that call [Preparer].
+var PrepareOperations = [2]Operation{Create, Update}
 
 func (o Operation) String() string {
 	switch o {

--- a/params.go
+++ b/params.go
@@ -1,53 +1,125 @@
-// TODO: create a query parser that always takes a SQL string with :name placeholders
-// and a list of sql.NamedArgs then returns a Query that is converted to the right
-// placeholder type and an []any array for the values.
-// TODO: See sqlx for an example of how they do feed forward parsing for named params.
 package tidal
 
 import (
 	"database/sql"
 	"fmt"
+	"strings"
+	"unicode"
+
+	"go.rtnl.ai/x/dsn"
 )
 
-func QueryParams(args []sql.NamedArg, placeholder PlaceholderType) Params {
-	params := Params{
-		placeholder:  placeholder,
-		placeholders: make(map[string]string),
-		values:       make([]any, len(args)),
-	}
+//============================================================================
+// QueryParams
+//============================================================================
 
-	for i, arg := range args {
-		switch placeholder {
-		case Positional:
-			params.placeholders[arg.Name] = "?"
-		case Ordered:
-			params.placeholders[arg.Name] = fmt.Sprintf("$%d", i+1)
-		case Named:
-			params.placeholders[arg.Name] = fmt.Sprintf(":%s", arg.Name)
-		case AtP:
-			params.placeholders[arg.Name] = "@p"
+// Rewrites canonical :name SQL and named arguments for the given driver style.
+func QueryParams(query string, args []sql.NamedArg, ph PlaceholderType) (*BoundQuery, error) {
+	switch ph {
+	case Named:
+		out := make([]any, len(args))
+		for i, arg := range args {
+			out[i] = arg
 		}
-		params.values = append(params.values, arg.Value)
+		return &BoundQuery{query: query, values: out}, nil
+	case Ordered:
+		return rewriteQuery(query, args, orderedPlaceholder)
+	case Positional:
+		return rewriteQuery(query, args, positionalPlaceholder)
+	case AtP:
+		return rewriteQuery(query, args, atpPlaceholder)
+	default:
+		return nil, ErrUnsupportedPlaceholder
+	}
+}
+
+//============================================================================
+// Helper Functions
+//============================================================================
+
+// Selects the placeholder type from a DSN provider name.
+func PlaceholderFor(provider string) PlaceholderType {
+	switch provider {
+	case dsn.Postgres:
+		return Ordered
+	case dsn.SQLite3:
+		return Named
+	default:
+		return UnknownPlaceholder
+	}
+}
+
+type placeholderFunc func(n int) string
+
+// orderedPlaceholder formats a Postgres positional placeholder (ex: $1, $2, $3, etc.).
+func orderedPlaceholder(n int) string { return fmt.Sprintf("$%d", n) }
+
+// positionalPlaceholder formats a SQLite-style positional placeholder (always returns '?').
+func positionalPlaceholder(_ int) string { return "?" }
+
+// atpPlaceholder formats an SQL Server-style positional placeholder (ex: @p1, @p2, @p3, etc.).
+func atpPlaceholder(n int) string { return fmt.Sprintf("@p%d", n) }
+
+// rewriteQuery replaces :name tokens in left-to-right order and builds matching args.
+func rewriteQuery(query string, args []sql.NamedArg, ph placeholderFunc) (*BoundQuery, error) {
+	var (
+		b      strings.Builder
+		values []any
+	)
+
+	byName := make(map[string]any, len(args))
+	for _, arg := range args {
+		byName[arg.Name] = arg.Value
 	}
 
-	return params
+	// Scan through each character in the input query string.
+	for i := 0; i < len(query); {
+		// Check if the current character is ':' indicating the start of a named placeholder (e.g., :name)
+		if query[i] == ':' && i+1 < len(query) {
+			// Continue scanning while the characters are valid identifier characters (letters, digits, or '_')
+			j := i + 1
+			for j < len(query) && isParamIdent(query[j]) {
+				j++
+			}
+
+			// Extract the parameter name found after ':'
+			if name := query[i+1 : j]; name != "" {
+				// Look up the named argument value by name in byName map
+				value, ok := byName[name]
+				if !ok {
+					// If not found, return an error indicating the missing argument
+					return nil, &MissingArgumentError{Name: name}
+				}
+
+				// Add the value to the values slice that will be the args for the query
+				values = append(values, value)
+
+				// Write the corresponding placeholder into the query string (e.g., $1, ?, @p, etc.)
+				b.WriteString(ph(len(values)))
+
+				// Move index i to just after the parameter name we just substituted
+				i = j
+				continue
+			}
+		}
+		// If current character is not the start of a placeholder, just copy it to the output buffer
+		b.WriteByte(query[i])
+		i++
+	}
+
+	return &BoundQuery{query: b.String(), values: values}, nil
 }
 
-type Params struct {
-	placeholder  PlaceholderType
-	placeholders map[string]string
-	values       []any
+// isParamIdent reports whether a byte may continue a :name placeholder identifier.
+func isParamIdent(r byte) bool {
+	return unicode.IsLetter(rune(r)) || unicode.IsDigit(rune(r)) || r == '_'
 }
 
-func (p Params) Placeholder(name string) (string, bool) {
-	placeholder, ok := p.placeholders[name]
-	return placeholder, ok
-}
+//============================================================================
+// Placeholder Types
+//============================================================================
 
-func (p Params) Args() []any {
-	return p.values
-}
-
+// PlaceholderType selects how :name placeholders are rewritten for a database driver.
 type PlaceholderType uint8
 
 const (
@@ -58,17 +130,22 @@ const (
 	AtP
 )
 
-func (p PlaceholderType) String() string {
-	switch p {
-	case Positional:
-		return "?"
-	case Ordered:
-		return "$N"
-	case Named:
-		return ":name"
-	case AtP:
-		return "@p"
-	default:
-		return "unknown"
-	}
+//============================================================================
+// BoundQuery
+//============================================================================
+
+// Holds a query and arguments ready for database/sql execution.
+type BoundQuery struct {
+	query  string
+	values []any
+}
+
+// SQL returns the query string with placeholders rewritten for the target driver.
+func (b *BoundQuery) SQL() string {
+	return b.query
+}
+
+// Args returns argument values in the order required by the rewritten query.
+func (b *BoundQuery) Args() []any {
+	return b.values
 }

--- a/params.go
+++ b/params.go
@@ -64,6 +64,10 @@ func atpPlaceholder(n int) string { return fmt.Sprintf("@p%d", n) }
 // When reuseByName is true, numbered placeholders ($1, @p1) reuse the same index for
 // repeated :name tokens. Anonymous placeholders cannot reuse a single arg slot, so
 // reuseByName must be false for positional only placeholders (like '?').
+//
+// NOTE: This function is very performant, and caching is probably not needed; this
+// was confirmed in benchmarks with cached vs uncached versions; the cached version
+// was complex and only ~5% faster.
 func rewriteQuery(query string, args []sql.NamedArg, ph placeholderFunc, reuseByName bool) (*BoundQuery, error) {
 	var (
 		b           strings.Builder

--- a/params.go
+++ b/params.go
@@ -23,11 +23,11 @@ func QueryParams(query string, args []sql.NamedArg, ph PlaceholderType) (*BoundQ
 		}
 		return &BoundQuery{query: query, values: out}, nil
 	case Ordered:
-		return rewriteQuery(query, args, orderedPlaceholder)
+		return rewriteQuery(query, args, orderedPlaceholder, true)
 	case Positional:
-		return rewriteQuery(query, args, positionalPlaceholder)
+		return rewriteQuery(query, args, positionalPlaceholder, false)
 	case AtP:
-		return rewriteQuery(query, args, atpPlaceholder)
+		return rewriteQuery(query, args, atpPlaceholder, true)
 	default:
 		return nil, ErrUnsupportedPlaceholder
 	}
@@ -61,11 +61,19 @@ func positionalPlaceholder(_ int) string { return "?" }
 func atpPlaceholder(n int) string { return fmt.Sprintf("@p%d", n) }
 
 // rewriteQuery replaces :name tokens in left-to-right order and builds matching args.
-func rewriteQuery(query string, args []sql.NamedArg, ph placeholderFunc) (*BoundQuery, error) {
+// When reuseByName is true, numbered placeholders ($1, @p1) reuse the same index for
+// repeated :name tokens. Anonymous placeholders cannot reuse a single arg slot, so
+// reuseByName must be false for positional only placeholders (like '?').
+func rewriteQuery(query string, args []sql.NamedArg, ph placeholderFunc, reuseByName bool) (*BoundQuery, error) {
 	var (
-		b      strings.Builder
-		values []any
+		b           strings.Builder
+		values      []any
+		indexByName map[string]int
 	)
+
+	if reuseByName {
+		indexByName = make(map[string]int, len(args))
+	}
 
 	byName := make(map[string]any, len(args))
 	for _, arg := range args {
@@ -76,6 +84,17 @@ func rewriteQuery(query string, args []sql.NamedArg, ph placeholderFunc) (*Bound
 	for i := 0; i < len(query); {
 		// Check if the current character is ':' indicating the start of a named placeholder (e.g., :name)
 		if query[i] == ':' && i+1 < len(query) {
+			// Postgres cast operator (::type) — copy through without binding.
+			if query[i+1] == ':' {
+				j := i + 2
+				for j < len(query) && isParamIdent(query[j]) {
+					j++
+				}
+				b.WriteString(query[i:j])
+				i = j
+				continue
+			}
+
 			// Continue scanning while the characters are valid identifier characters (letters, digits, or '_')
 			j := i + 1
 			for j < len(query) && isParamIdent(query[j]) {
@@ -91,11 +110,18 @@ func rewriteQuery(query string, args []sql.NamedArg, ph placeholderFunc) (*Bound
 					return nil, &MissingArgumentError{Name: name}
 				}
 
-				// Add the value to the values slice that will be the args for the query
-				values = append(values, value)
-
-				// Write the corresponding placeholder into the query string (e.g., $1, ?, @p, etc.)
-				b.WriteString(ph(len(values)))
+				// If the same :name token appears twice, reuse the same
+				// placeholder index if reuseByName is true.
+				if idx, ok := indexByName[name]; ok {
+					b.WriteString(ph(idx))
+				} else {
+					values = append(values, value)
+					idx := len(values)
+					if reuseByName {
+						indexByName[name] = idx
+					}
+					b.WriteString(ph(idx))
+				}
 
 				// Move index i to just after the parameter name we just substituted
 				i = j

--- a/params_test.go
+++ b/params_test.go
@@ -1,0 +1,85 @@
+package tidal
+
+import (
+	"database/sql"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// Tests that [QueryParams] rewrites :name placeholders for the given placeholder type.
+func TestQueryParams(t *testing.T) {
+	// Prepare test data for all tests
+
+	const complex = "named_with_underscore_and_123_nums"
+	query := "INSERT INTO items (sku, qty, note) VALUES (:" + complex + ", :qty, :alpha_bravo) WHERE tenant_id = :tenant_id"
+	args := []sql.NamedArg{
+		sql.Named(complex, "SKU-42"),
+		sql.Named("qty", 7),
+		sql.Named("alpha_bravo", "notes"),
+		sql.Named("tenant_id", 99),
+	}
+	wantValues := []any{"SKU-42", 7, "notes", 99}
+
+	// Happy Path
+
+	t.Run("Positional", func(t *testing.T) {
+		b, err := QueryParams(query, args, Positional)
+		require.NoError(t, err)
+		require.Equal(t,
+			"INSERT INTO items (sku, qty, note) VALUES (?, ?, ?) WHERE tenant_id = ?",
+			b.SQL(),
+		)
+		require.Equal(t, wantValues, b.Args())
+	})
+
+	t.Run("Ordered", func(t *testing.T) {
+		b, err := QueryParams(query, args, Ordered)
+		require.NoError(t, err)
+		require.Equal(t,
+			"INSERT INTO items (sku, qty, note) VALUES ($1, $2, $3) WHERE tenant_id = $4",
+			b.SQL(),
+		)
+		require.Equal(t, wantValues, b.Args())
+	})
+
+	t.Run("Named", func(t *testing.T) {
+		b, err := QueryParams(query, args, Named)
+		require.NoError(t, err)
+		require.Equal(t, query, b.SQL())
+		require.Equal(t, []any{
+			sql.Named(complex, "SKU-42"),
+			sql.Named("qty", 7),
+			sql.Named("alpha_bravo", "notes"),
+			sql.Named("tenant_id", 99),
+		}, b.Args())
+	})
+
+	t.Run("AtP", func(t *testing.T) {
+		b, err := QueryParams(query, args, AtP)
+		require.NoError(t, err)
+		require.Equal(t,
+			"INSERT INTO items (sku, qty, note) VALUES (@p1, @p2, @p3) WHERE tenant_id = @p4",
+			b.SQL(),
+		)
+		require.Equal(t, wantValues, b.Args())
+	})
+
+	// Failures / Errors
+
+	t.Run("UnknownPlaceholder", func(t *testing.T) {
+		_, err := QueryParams(query, args, UnknownPlaceholder)
+		require.ErrorIs(t, err, ErrUnsupportedPlaceholder, "unknown placeholder type should return an error")
+	})
+
+	t.Run("MissingArgument", func(t *testing.T) {
+		_, err := QueryParams(
+			"SELECT * FROM items WHERE sku = :sku",
+			[]sql.NamedArg{},
+			Ordered,
+		)
+		var missing *MissingArgumentError
+		require.ErrorAs(t, err, &missing)
+		require.Equal(t, "sku", missing.Name)
+	})
+}

--- a/params_test.go
+++ b/params_test.go
@@ -82,4 +82,54 @@ func TestQueryParams(t *testing.T) {
 		require.ErrorAs(t, err, &missing)
 		require.Equal(t, "sku", missing.Name)
 	})
+
+	// Placeholder Rewriter Edge Cases
+
+	// Bound arg values follow left-to-right query appearance, not the NamedArg slice order.
+	t.Run("ArgOrderFollowsQueryText", func(t *testing.T) {
+		b, err := QueryParams(
+			"SELECT * FROM t WHERE a = :b AND b = :a",
+			[]sql.NamedArg{sql.Named("a", 1), sql.Named("b", 2)},
+			Ordered,
+		)
+		require.NoError(t, err)
+		require.Equal(t, "SELECT * FROM t WHERE a = $1 AND b = $2", b.SQL())
+		require.Equal(t, []any{2, 1}, b.Args())
+	})
+
+	// Repeated :name tokens reuse the same numbered placeholder and bind once.
+	t.Run("RepeatedPlaceholderOrdered", func(t *testing.T) {
+		b, err := QueryParams(
+			"SELECT * FROM t WHERE id = :id OR parent_id = :id",
+			[]sql.NamedArg{sql.Named("id", 42)},
+			Ordered,
+		)
+		require.NoError(t, err)
+		require.Equal(t, "SELECT * FROM t WHERE id = $1 OR parent_id = $1", b.SQL())
+		require.Equal(t, []any{42}, b.Args())
+	})
+
+	// Anonymous ? placeholders still need one arg per occurrence — no index reuse.
+	t.Run("RepeatedPlaceholderPositional", func(t *testing.T) {
+		b, err := QueryParams(
+			"SELECT * FROM t WHERE id = :id OR parent_id = :id",
+			[]sql.NamedArg{sql.Named("id", 42)},
+			Positional,
+		)
+		require.NoError(t, err)
+		require.Equal(t, "SELECT * FROM t WHERE id = ? OR parent_id = ?", b.SQL())
+		require.Equal(t, []any{42, 42}, b.Args())
+	})
+
+	// Postgres ::type casts must pass through without being treated as :name placeholders.
+	t.Run("PostgresCastWithNamedArg", func(t *testing.T) {
+		b, err := QueryParams(
+			"SELECT * FROM t WHERE id::text = :id",
+			[]sql.NamedArg{sql.Named("id", "abc")},
+			Ordered,
+		)
+		require.NoError(t, err)
+		require.Equal(t, "SELECT * FROM t WHERE id::text = $1", b.SQL())
+		require.Equal(t, []any{"abc"}, b.Args())
+	})
 }

--- a/row.go
+++ b/row.go
@@ -1,0 +1,31 @@
+package tidal
+
+import "database/sql"
+
+// Row is the result of calling [Tx.QueryRow] to select a single row. It mirrors
+// [sql.Row]: errors from query execution or parameter binding are returned from
+// [Row.Scan] and [Row.Err], not from [Tx.QueryRow].
+type Row struct {
+	row *sql.Row
+	err error
+}
+
+// Scan copies the columns from the matching row into dest, delegating to the
+// underlying [sql.Row] when the query was executed successfully.
+func (r *Row) Scan(dest ...any) error {
+	if r.err != nil {
+		return r.err
+	}
+	return r.row.Scan(dest...)
+}
+
+// Err returns any error deferred while preparing or running the query.
+func (r *Row) Err() error {
+	if r.err != nil {
+		return r.err
+	}
+	if r.row != nil {
+		return r.row.Err()
+	}
+	return nil
+}

--- a/row_test.go
+++ b/row_test.go
@@ -1,0 +1,29 @@
+package tidal_test
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.rtnl.ai/tidal"
+	"go.rtnl.ai/x/dsn"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+// QueryRow bind failures return a Row; the error shows up on Scan and Err.
+func TestRowBindError(t *testing.T) {
+	db, err := sql.Open("sqlite3", ":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	tidalDB := tidal.Wrap(db, &dsn.DSN{Provider: "mysql"})
+	tx, err := tidalDB.BeginTx(context.Background(), nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = tx.Rollback() })
+
+	row := tx.QueryRow("SELECT :x", sql.Named("x", 1))
+	require.ErrorIs(t, row.Scan(new(int)), tidal.ErrUnsupportedPlaceholder)
+	require.ErrorIs(t, row.Err(), tidal.ErrUnsupportedPlaceholder)
+}

--- a/suite/crud.go
+++ b/suite/crud.go
@@ -1,0 +1,489 @@
+package suite
+
+import (
+	"database/sql"
+	"errors"
+	"fmt"
+	"reflect"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+	"unicode"
+
+	"go.rtnl.ai/tidal"
+	"go.rtnl.ai/ulid"
+)
+
+// Configuration for a model conformance run against [tidal.CRUD].
+//
+// The caller supplies a table name, a factory for fresh models, and an update
+// mutator. Everything else is handled by the suite: shape checks, an isolated
+// Scan check (no database), and a full CRUD round-trip against the real database
+// connection already set up on [DatabaseSuite] (rolled back at the end).
+type CRUDConformance[M tidal.Model] struct {
+	// Database table the model maps to.
+	Table string
+
+	// Returns a fresh model suitable for insert. Values that must be unique across
+	// runs (such as email) should be generated here.
+	Create func() M
+
+	// Mutates a model in place to exercise the update path during round-trip.
+	// The same instance that was created and inserted is passed here.
+	Update func(M)
+
+	// Optional comparison for retrieved and scanned models. When nil, a default
+	// comparison is used that tolerates database timestamp truncation and compares
+	// ULIDs by value. Provide a custom function when models include field types that
+	// need special handling (for example JSONB normalization).
+	Equal func(a, b M) bool
+}
+
+// Runs three independent conformance phases against a [tidal.Model] implementation.
+//
+//   - Shape: static checks on Fields/Params/SQL only; no database, no CRUD calls.
+//   - Scan: exercises Scan with a fake row built from Params; no database, no CRUD calls.
+//   - RoundTrip: exercises real [tidal.CRUD] methods against the suite database inside
+//     a transaction that is always rolled back; nothing is committed.
+//
+// This does not mock tidal, patch the model, or substitute a fake database for
+// round-trip. The only "fake" piece is mockScanner, used exclusively in the Scan phase.
+func ModelConformsCRUD[M tidal.Model](s *DatabaseSuite, cfg CRUDConformance[M]) {
+	s.T().Helper()
+	require := s.Require()
+	require.NotEmpty(cfg.Table, "table is required")
+	require.NotNil(cfg.Create, "create is required")
+	require.NotNil(cfg.Update, "update is required")
+
+	crud := tidal.New[M](cfg.Table)
+
+	s.Run("Shape", func() {
+		testCRUDShape(s, cfg, crud)
+	})
+
+	s.Run("Scan", func() {
+		testCRUDScan(s, cfg, cfg.Equal)
+	})
+
+	s.Run("RoundTrip", func() {
+		testCRUDRoundTrip(s, cfg, crud, cfg.Equal)
+	})
+}
+
+// Static metadata checks. Does not open a transaction, does not call CRUD Create/
+// Retrieve/Update/Delete, and does not read or write the database.
+//
+// A single model from Create() is inspected. We only call Fields and Params on it.
+func testCRUDShape[M tidal.Model](s *DatabaseSuite, cfg CRUDConformance[M], crud *tidal.CRUD[M]) {
+	s.T().Helper()
+	require := s.Require()
+	m := cfg.Create()
+
+	for _, op := range []tidal.Operation{tidal.List, tidal.Create, tidal.Retrieve, tidal.Update} {
+		s.Run(op.String(), func() {
+			// --- Fields(op): column names this operation expects ---
+			fields := m.Fields(op)
+			require.NotEmpty(fields, "Fields(%s) must not be empty", op)
+
+			for _, field := range fields {
+				require.NotEmpty(field, "Fields(%s) must not contain empty names", op)
+			}
+
+			// List only defines which columns Scan reads; it has no Params in CRUD.
+			if op == tidal.List {
+				return
+			}
+
+			// --- Params(op): named bind values for write/select-full-row operations ---
+			params := m.Params(op)
+			require.NotEmpty(params, "Params(%s) must not be empty", op)
+
+			names := make([]string, 0, len(params))
+			for _, param := range params {
+				require.NotEmpty(param.Name, "Params(%s) must not contain empty names", op)
+				require.False(slices.Contains(names, param.Name), "Params(%s) contains duplicate name %q", op, param.Name)
+				names = append(names, param.Name)
+
+				// Every param name must appear in Fields for this operation so SQL and
+				// bindings stay aligned.
+				require.Contains(fields, param.Name, "Params(%s) name %q is not in Fields(%s)", op, param.Name, op)
+			}
+		})
+	}
+
+	// --- Query strings: smoke-check that [tidal.New] produced non-empty SQL ---
+	s.Run("Queries", func() {
+		require.NotEmpty(crud.Queries.List)
+		require.NotEmpty(crud.Queries.Create)
+		require.NotEmpty(crud.Queries.Retrieve)
+		require.NotEmpty(crud.Queries.Update)
+		require.NotEmpty(crud.Queries.Delete)
+	})
+}
+
+// Isolated Scan check. Does not use [tidal.CRUD] and does not touch the database.
+//
+// For each operation we:
+//  1. Build a model with Create() ("original").
+//  2. Derive fake row values from Params in Fields order (valuesForScan).
+//  3. Feed those values into Scan via mockScanner (pretends to be *sql.Rows).
+//  4. Compare the scanned model to original.
+//
+// This catches Scan/Fields/Params mismatches before paying for a DB round-trip.
+// List is omitted because it uses a different column subset than Create/Retrieve.
+func testCRUDScan[M tidal.Model](s *DatabaseSuite, cfg CRUDConformance[M], equal func(a, b M) bool) {
+	s.T().Helper()
+	require := s.Require()
+	equalFn := equal
+	if equalFn == nil {
+		equalFn = func(a, b M) bool { return defaultEqual(s.T(), a, b) }
+	}
+
+	for _, op := range []tidal.Operation{tidal.Create, tidal.Retrieve, tidal.Update} {
+		s.Run(op.String(), func() {
+			// Source of truth: what the caller's factory produces.
+			original := cfg.Create()
+
+			// NOT a database row — values assembled from Params to mimic what a row
+			// would contain if Params and Fields are consistent.
+			values := valuesForScan(s.T(), original, op)
+			require.Len(values, len(original.Fields(op)), "scan values and Fields(%s) length mismatch", op)
+
+			// Fresh zero instance; only Scan should populate it.
+			got := tidal.Make[M]()
+			require.NoError(got.Scan(op, &mockScanner{values: values}))
+			require.True(equalFn(original, got), "Scan(%s) did not round-trip model values", op)
+		})
+	}
+}
+
+// Full integration check against the real suite database ([DatabaseSuite].DB).
+//
+// Uses [tidal.CRUD] exactly as production code would. All work happens inside one
+// transaction that is rolled back in defer — no commits, no persistent side effects.
+//
+// Does not use mockScanner or a mock database here.
+func testCRUDRoundTrip[M tidal.Model](s *DatabaseSuite, cfg CRUDConformance[M], crud *tidal.CRUD[M], equal func(a, b M) bool) {
+	s.T().Helper()
+	require := s.Require()
+	equalFn := equal
+	if equalFn == nil {
+		equalFn = func(a, b M) bool { return defaultEqual(s.T(), a, b) }
+	}
+
+	// Real transaction on the suite's live DB connection (SQLite file or Postgres).
+	tx := s.BeginTx(nil)
+	defer tx.Rollback() // always discarded — nothing survives this test
+
+	// --- CREATE ---
+	// Model from caller's factory; CRUD Create will call Prepare/Validate if implemented,
+	// then Exec INSERT using the model's Params(Create).
+	created := cfg.Create()
+	_, err := crud.Create(tx, created)
+	require.NoError(err, "Create failed")
+
+	// If the model embeds BaseModel (Preparer), Create should have assigned an ID.
+	if _, ok := any(created).(tidal.Preparer); ok {
+		require.False(reflect.ValueOf(modelID(s.T(), created).Value).IsZero(), "ID should be set after Create")
+	}
+
+	// --- RETRIEVE (after create) ---
+	// Reads the row back with SELECT ... WHERE id = :id. Compare in-memory created
+	// (post-Prepare) against what Scan pulled from the database.
+	retrieved, err := crud.Retrieve(tx, modelID(s.T(), created))
+	require.NoError(err, "Retrieve after Create failed")
+	require.True(equalFn(created, retrieved), "Retrieve after Create returned unexpected model")
+
+	// --- LIST ---
+	// Uses CRUD List with a manual WHERE clause filter. Expect exactly the row we inserted.
+	// List scans fewer columns than Retrieve (per model's Fields(List)).
+	filter := &tidal.Clause{
+		SQL:  "WHERE id = :id",
+		Args: []sql.NamedArg{modelID(s.T(), created)},
+	}
+
+	cursor, err := crud.List(tx, filter)
+	require.NoError(err, "List failed")
+
+	models, err := cursor.List()
+	require.NoError(err, "List cursor failed")
+
+	// SQLite blocks writes in the same transaction while sql.Rows is open; close
+	// the result set only (not the transaction — cursor.Close would Rollback).
+	require.NoError(tidal.CloseRows(cursor), "List cursor close failed")
+	require.Len(models, 1, "List should return exactly one model")
+
+	// Compare only List columns (not full struct — List Scan omits password, etc.).
+	require.True(equalListFields(s.T(), created, models[0], created.Fields(tidal.List)), "List returned unexpected model")
+
+	// --- UPDATE ---
+	// Caller mutates the same in-memory instance; CRUD Update runs Prepare/Validate
+	// then Exec UPDATE using Params(Update).
+	cfg.Update(created) // created is mutated in place
+	require.NoError(crud.Update(tx, created), "Update failed")
+
+	// --- RETRIEVE (after update) ---
+	updated, err := crud.Retrieve(tx, modelID(s.T(), created))
+	require.NoError(err, "Retrieve after Update failed")
+	require.True(equalFn(created, updated), "Retrieve after Update returned unexpected model")
+
+	// --- DELETE ---
+	_, err = crud.Delete(tx, modelID(s.T(), created))
+	require.NoError(err, "Delete failed")
+
+	// --- RETRIEVE (after delete) ---
+	// Row should be gone; tidal returns sql.ErrNoRows from Scan on empty result.
+	_, err = crud.Retrieve(tx, modelID(s.T(), created))
+	require.Error(err, "Retrieve after Delete should fail")
+	require.True(errors.Is(err, sql.ErrNoRows), "Retrieve after Delete should return sql.ErrNoRows")
+}
+
+// Reads the primary key from Params(Create) on an already-populated model.
+func modelID[M tidal.Model](t testing.TB, m M) sql.NamedArg {
+	t.Helper()
+	for _, param := range m.Params(tidal.Create) {
+		if param.Name == "id" {
+			return sql.Named("id", param.Value)
+		}
+	}
+	t.Fatalf("model %T does not expose id in Params(Create)", m)
+	return sql.NamedArg{}
+}
+
+// Assembles fake row values for the Scan phase only.
+//
+// Takes values from Params (Create as base, then overlaid with Params(op)) and
+// orders them to match Fields(op) — the same order Scan passes to sql.Rows.Scan.
+// If a field appears in Fields but not in Params, the test fails (that is a model bug).
+func valuesForScan[M tidal.Model](t testing.TB, m M, op tidal.Operation) []any {
+	t.Helper()
+	// Scan reads columns in Fields(op) order — this slice must match that exactly.
+	fields := m.Fields(op)
+
+	// Build a name→value lookup. Start with Create params (full row shape), then
+	// overlay Params(op) so operation-specific bindings win (e.g. Update timestamps).
+	byName := make(map[string]any, len(fields))
+	for _, param := range m.Params(tidal.Create) {
+		byName[param.Name] = param.Value
+	}
+	for _, param := range m.Params(op) {
+		byName[param.Name] = param.Value
+	}
+
+	// Emit values in Fields order, not map iteration order.
+	values := make([]any, len(fields))
+	for i, field := range fields {
+		value, ok := byName[field]
+		if !ok {
+			// Every column Scan expects must have a bind value somewhere in Params.
+			t.Fatalf("model %T is missing value for Fields(%s) entry %q", m, op, field)
+		}
+		values[i] = value
+	}
+	return values
+}
+
+// Default Equal when the caller does not provide one.
+func defaultEqual[M tidal.Model](tb testing.TB, a, b M) bool {
+	tb.Helper()
+	return equalValues(tb, reflect.ValueOf(a), reflect.ValueOf(b))
+}
+
+// Compares two models on the subset of columns returned by Fields(List). List
+// Scan does not populate password, dob, etc., so we must not use full struct
+// Equal.
+func equalListFields[M tidal.Model](tb testing.TB, a, b M, columns []string) bool {
+	tb.Helper()
+	av := reflect.ValueOf(a)
+	bv := reflect.ValueOf(b)
+
+	// Models may be values or pointers; compare the struct underneath.
+	for av.Kind() == reflect.Ptr {
+		av = av.Elem()
+	}
+	for bv.Kind() == reflect.Ptr {
+		bv = bv.Elem()
+	}
+
+	// Only check columns List actually scanned — unlisted fields stay zero-valued
+	// on the List result and must not be compared.
+	for _, column := range columns {
+		af, ok := fieldByColumn(tb, av, column)
+		if !ok {
+			return false
+		}
+		bf, ok := fieldByColumn(tb, bv, column)
+		if !ok {
+			return false
+		}
+		if !equalValues(tb, af, bf) {
+			return false
+		}
+	}
+	return true
+}
+
+// Reflective deep compare with special cases for types that round-trip through
+// SQL poorly.
+func equalValues(tb testing.TB, a, b reflect.Value) bool {
+	tb.Helper()
+
+	// Peel pointers and interface wrappers until we reach concrete values.
+	for a.Kind() == reflect.Ptr || a.Kind() == reflect.Interface {
+		if a.IsNil() || b.IsNil() {
+			return a.IsNil() && b.IsNil()
+		}
+		a = a.Elem()
+		b = b.Elem()
+	}
+
+	if a.Type() != b.Type() {
+		return false
+	}
+
+	switch a.Kind() {
+	case reflect.Struct:
+		// Types that survive a DB round-trip but not reflect.DeepEqual:
+		// time.Time, sql.NullTime, ulid.ULID.
+		if a.Type() == reflect.TypeOf(time.Time{}) {
+			return timesEqual(tb, a.Interface().(time.Time), b.Interface().(time.Time))
+		}
+		if a.Type() == reflect.TypeOf(sql.NullTime{}) {
+			at := a.Interface().(sql.NullTime)
+			bt := b.Interface().(sql.NullTime)
+			if at.Valid != bt.Valid {
+				return false
+			}
+			if !at.Valid {
+				return true // both NULL — skip time comparison
+			}
+			return timesEqual(tb, at.Time, bt.Time)
+		}
+		if a.Type() == reflect.TypeOf(ulid.ULID{}) {
+			// ULID is a [16]byte array; == compares bytes, not pointer identity.
+			return a.Interface().(ulid.ULID) == b.Interface().(ulid.ULID)
+		}
+		// Generic struct: recurse field-by-field (handles embedded fields too).
+		for i := 0; i < a.NumField(); i++ {
+			if !equalValues(tb, a.Field(i), b.Field(i)) {
+				return false
+			}
+		}
+		return true
+	default:
+		return reflect.DeepEqual(a.Interface(), b.Interface())
+	}
+}
+
+// Locates a struct field for a database column name (snake_case), including embedded structs.
+func fieldByColumn(tb testing.TB, v reflect.Value, column string) (reflect.Value, bool) {
+	tb.Helper()
+	typ := v.Type()
+	for i := 0; i < typ.NumField(); i++ {
+		field := typ.Field(i)
+		if field.Anonymous {
+			// Embedded BaseModel, etc. — search inside before giving up.
+			if fv, ok := fieldByColumn(tb, v.Field(i), column); ok {
+				return fv, true
+			}
+			continue
+		}
+
+		// Match DB column name (snake_case) to Go field name (CamelCase).
+		if columnName(tb, field.Name) == column {
+			return v.Field(i), true
+		}
+	}
+	return reflect.Value{}, false
+}
+
+// Maps Go field names to column names (ID -> id, LastSeen -> last_seen).
+func columnName(tb testing.TB, field string) string {
+	tb.Helper()
+	// Mirrors tidal's default column naming: CamelCase → snake_case.
+	// Inserts '_' before an uppercase rune when it starts a new word:
+	//   LastSeen  → last_seen  (lower→upper boundary)
+	//   UserID    → user_id    (upper followed by upper+lower, e.g. "ID")
+	var b strings.Builder
+	for i, r := range field {
+		if i > 0 && unicode.IsUpper(r) {
+			prev := rune(field[i-1])
+			var next rune
+			if i+1 < len(field) {
+				next = rune(field[i+1])
+			}
+			// Split on lower→Upper (LastSeen) or Upper→Upper+lower (UserID).
+			if unicode.IsLower(prev) || (next != 0 && unicode.IsLower(next)) {
+				b.WriteByte('_')
+			}
+		}
+		b.WriteRune(unicode.ToLower(r))
+	}
+	return b.String()
+}
+
+// Database drivers often truncate timestamps; compare at second precision in UTC.
+func timesEqual(tb testing.TB, a, b time.Time) bool {
+	tb.Helper()
+	if a.IsZero() && b.IsZero() {
+		return true
+	}
+	// SQLite stores datetimes without sub-second precision; Postgres may differ
+	// in location. Normalize before comparing in-memory vs retrieved values.
+	return a.UTC().Truncate(time.Second).Equal(b.UTC().Truncate(time.Second))
+}
+
+// Fake [tidal.Scanner] for the Scan phase only. Holds predetermined cell values
+// and assigns them into the pointers Scan passes — same contract as *sql.Rows.Scan.
+// Never connects to a database.
+type mockScanner struct {
+	values []any
+}
+
+// Satisfies [tidal.Scanner]. Copies predetermined values into dest pointers.
+func (m *mockScanner) Scan(dest ...any) error {
+	// model.Scan passes one pointer per Fields(op) column — count must match our
+	// fake row built by valuesForScan.
+	if len(dest) != len(m.values) {
+		return fmt.Errorf("mockScanner: expected %d destinations, got %d", len(m.values), len(dest))
+	}
+
+	for i, d := range dest {
+		// dest entries are *T pointers; assignValue writes through them like sql.Rows.Scan.
+		if err := assignValue(d, m.values[i]); err != nil {
+			return fmt.Errorf("mockScanner: destination %d: %w", i, err)
+		}
+	}
+	return nil
+}
+
+// Reflective assignment helper for mockScanner.Scan.
+func assignValue(dest, value any) error {
+	dv := reflect.ValueOf(dest)
+	if dv.Kind() != reflect.Ptr || dv.IsNil() {
+		return fmt.Errorf("destination must be a non-nil pointer")
+	}
+
+	dv = dv.Elem() // *T → T, the field Scan wants populated
+	vv := reflect.ValueOf(value)
+
+	if !vv.IsValid() {
+		// nil interface in the fake row → zero the destination (SQL NULL).
+		dv.SetZero()
+		return nil
+	}
+
+	if vv.Type().AssignableTo(dv.Type()) {
+		dv.Set(vv)
+		return nil
+	}
+
+	// e.g. int64 source into a typed alias or narrower numeric field.
+	if vv.Type().ConvertibleTo(dv.Type()) {
+		dv.Set(vv.Convert(dv.Type()))
+		return nil
+	}
+
+	return fmt.Errorf("cannot assign %T to %T", value, dest)
+}

--- a/suite/crud.go
+++ b/suite/crud.go
@@ -49,7 +49,7 @@ type CRUDConformance[M tidal.Model] struct {
 //
 // This does not mock tidal, patch the model, or substitute a fake database for
 // round-trip. The only "fake" piece is mockScanner, used exclusively in the Scan phase.
-func ModelConformsCRUD[M tidal.Model](s *DatabaseSuite, cfg CRUDConformance[M]) {
+func ConformsCRUD[M tidal.Model](s *DatabaseSuite, cfg CRUDConformance[M]) {
 	s.T().Helper()
 	require := s.Require()
 	require.NotEmpty(cfg.Table, "table is required")
@@ -211,7 +211,7 @@ func testCRUDRoundTrip[M tidal.Model](s *DatabaseSuite, cfg CRUDConformance[M], 
 
 	// SQLite blocks writes in the same transaction while sql.Rows is open; close
 	// the result set only (not the transaction — cursor.Close would Rollback).
-	require.NoError(tidal.CloseRows(cursor), "List cursor close failed")
+	require.NoError(cursor.CloseRows(), "List cursor close failed")
 	require.Len(models, 1, "List should return exactly one model")
 
 	// Compare only List columns (not full struct — List Scan omits password, etc.).
@@ -401,26 +401,72 @@ func fieldByColumn(tb testing.TB, v reflect.Value, column string) (reflect.Value
 // Maps Go field names to column names (ID -> id, LastSeen -> last_seen).
 func columnName(tb testing.TB, field string) string {
 	tb.Helper()
-	// Mirrors tidal's default column naming: CamelCase → snake_case.
-	// Inserts '_' before an uppercase rune when it starts a new word:
-	//   LastSeen  → last_seen  (lower→upper boundary)
-	//   UserID    → user_id    (upper followed by upper+lower, e.g. "ID")
 	var b strings.Builder
 	for i, r := range field {
-		if i > 0 && unicode.IsUpper(r) {
+		if i > 0 {
 			prev := rune(field[i-1])
-			var next rune
-			if i+1 < len(field) {
-				next = rune(field[i+1])
-			}
-			// Split on lower→Upper (LastSeen) or Upper→Upper+lower (UserID).
-			if unicode.IsLower(prev) || (next != 0 && unicode.IsLower(next)) {
-				b.WriteByte('_')
+			if unicode.IsUpper(r) || (unicode.IsDigit(prev) && unicode.IsLetter(r)) {
+				var next rune
+				if i+1 < len(field) {
+					next = rune(field[i+1])
+				}
+				if shouldSplitColumnName(field, i, r, prev, next) {
+					b.WriteByte('_')
+				}
 			}
 		}
 		b.WriteRune(unicode.ToLower(r))
 	}
 	return b.String()
+}
+
+// shouldSplitColumnName applies CamelCase → snake_case word-boundary rules:
+//
+//  1. Classic camelCase:     lower → Upper → lower     (LastSeen, GoVariable)
+//  2. Acronym → word:        Upper → Upper... → lower  (URLPath, HTTPHeader)
+//  3. Word → acronym suffix: lower → Upper...          (UserID, UserA, etc.)
+//  4. Acronym particle:      Cap–lower–Cap           (DoB, MoU — suppress split)
+//  5. Digit boundary:        digit → letter          (v2API, v2api, OAuth2Token)
+func shouldSplitColumnName(field string, i int, r, prev, next rune) bool {
+	split := false
+
+	// Rule 1: lower → Upper → lower
+	if unicode.IsLower(prev) && next != 0 && unicode.IsLower(next) {
+		split = true
+	}
+
+	// Rule 2: upper → Upper → lower (skip OA… / IPv… continuations at i==1)
+	if unicode.IsUpper(prev) && next != 0 && unicode.IsLower(next) {
+		if !(i == 1 && unicode.IsUpper(rune(field[0])) && unicode.IsUpper(r)) {
+			split = true
+		}
+	}
+
+	// Rule 3: lower → Upper… — trailing initial (UserA) or uppercase suffix (UserID)
+	if unicode.IsLower(prev) && (next == 0 || unicode.IsUpper(next)) {
+		split = true
+	}
+
+	// Rule 4: Cap–lower–Cap particle — suppress split (DoB, QoL) or undo rule 3
+	// when closing before the next word (QoLUser).
+	if i >= 2 && unicode.IsLower(prev) && unicode.IsUpper(rune(field[i-2])) {
+		switch {
+		case next != 0 && unicode.IsUpper(next):
+			// like 'QoLUser' — suppress split (wait for rule 2 at the next word)
+			split = false
+		case (next == 0 || unicode.IsUpper(next)) &&
+			(i+1 >= len(field) || !unicode.IsUpper(rune(field[i+1]))):
+			// like 'DoB', QoL — suppress split (single closing upper)
+			split = false
+		}
+	}
+
+	// Rule 5: digit → letter (version or numeric prefix before suffix)
+	if unicode.IsDigit(prev) && unicode.IsLetter(r) {
+		split = true
+	}
+
+	return split
 }
 
 // Database drivers often truncate timestamps; compare at second precision in UTC.

--- a/suite/crud_test.go
+++ b/suite/crud_test.go
@@ -1,0 +1,349 @@
+package suite
+
+import (
+	"database/sql"
+	"fmt"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.rtnl.ai/tidal"
+	"go.rtnl.ai/ulid"
+)
+
+//============================================================================
+// columnName
+//============================================================================
+
+// Verifies CamelCase → snake_case mapping used by [fieldByColumn] and [equalListFields].
+func TestColumnName(t *testing.T) {
+	tests := []struct {
+		field string
+		want  string
+	}{
+		// no split — all lowercase, all caps, acronym-with-digit tail, rule 2 OA/IPv exception
+		{"lowercase", "lowercase"},
+		{"A", "a"},
+		{"ID", "id"},
+		{"HTTP", "http"},
+		{"SOS", "sos"},
+		{"CAPTCHA", "captcha"},
+		{"UTF8", "utf8"},
+		{"OAuth", "oauth"},
+		{"OAuth2", "oauth2"},
+		{"IPv6", "ipv6"},
+		{"IPv666", "ipv666"}, // the devil's favorite layer 3 protocol
+
+		// Rule 1: lower → Upper → lower
+		{"LastSeen", "last_seen"},
+		{"GoVariable", "go_variable"},
+		{"VeryLongCapitalizedNameHasALotOfWords", "very_long_capitalized_name_has_a_lot_of_words"},
+		{"QualityOfLife", "quality_of_life"},
+		{"DateOfBirth", "date_of_birth"},
+
+		// Rule 2: Upper… → lower
+		{"URLPath", "url_path"},
+		{"APIKey", "api_key"},
+		{"JSONData", "json_data"},
+		{"HTMLParser", "html_parser"},
+		{"XMLHttp", "xml_http"},
+		{"HTTPServer", "http_server"},
+		{"ABTest", "ab_test"},
+
+		// Rule 3: lower → Upper…
+		{"UserID", "user_id"},
+		{"UserA", "user_a"},
+		{"NetflixID", "netflix_id"},
+		{"UserAB", "user_ab"},
+		{"UserHTTP", "user_http"},
+		{"getHTTP", "get_http"},
+
+		// Rule 4: Cap–lower–Cap particle — suppress split
+		{"DoB", "dob"},
+		{"QoL", "qol"},
+		{"MoU", "mou"},
+		{"SoS", "sos"},
+		{"IoT", "iot"},
+
+		// Rule 5: digit → letter
+		{"v2API", "v2_api"},
+		{"V2API", "v2_api"},
+		{"v2api", "v2_api"},
+		{"V2api", "v2_api"},
+		{"12angrymen", "12_angrymen"},
+
+		// combinations — multiple rules in one name
+		{"UserQoL", "user_qol"},                                // word → acronym particle
+		{"HasAMiddleQoLParticle", "has_a_middle_qol_particle"}, // acronym particle in middle of words
+		{"UserIDAndEmail", "user_id_and_email"},                // word → acronym → word
+		{"SomethingHTTPHeader", "something_http_header"},       // word → acronym → word
+		{"QoLUser", "qol_user"},                                // acronym particle → word
+		{"SoSUser", "sos_user"},                                // acronym particle → word
+		{"IoTDevice", "iot_device"},                            // acronym particle → word
+		{"OAuth2Token", "oauth2_token"},                        // initial capital character exception + digit boundary
+		{"12AngryMen", "12_angry_men"},                         // digit boundary + word
+
+		// known limitations — proper nouns, lowercase brand prefixes, etc.
+		{"iOS", "i_os"},
+		{"iOSSDK", "i_ossdk"},
+		{"iOSApp", "i_os_app"},
+		{"tvOS", "tv_os"},
+		{"macOS", "mac_os"},
+		{"eBay", "e_bay"},
+		{"iTunes", "i_tunes"},
+		{"McDonalds", "mc_donalds"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.field, func(t *testing.T) {
+			require.Equal(t, tc.want, columnName(t, tc.field))
+		})
+	}
+}
+
+//============================================================================
+// valuesForScan
+//============================================================================
+
+// Verifies [valuesForScan] assembles fake row values in Fields(op) order from Params.
+func TestValuesForScan(t *testing.T) {
+	uid := ulid.MustParse("01KTESYNDPVTRWK05N2TXFKGQZ")
+	other := ulid.MustParse("01KTESYNDPVTRWK05N2TXFKGQ0")
+	seen := sql.NullTime{Valid: true, Time: time.Date(2024, 6, 1, 12, 0, 0, 0, time.UTC)}
+	created := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	modified := time.Date(2024, 2, 1, 0, 0, 0, 0, time.UTC)
+
+	m := &scanHelperModel{
+		BaseModel: tidal.BaseModel{ID: uid, Created: created, Modified: modified},
+		URLPath:   "/v1/items",
+		UserID:    other,
+		LastSeen:  seen,
+	}
+
+	t.Run("RetrieveFieldsOrder", func(t *testing.T) {
+		// Full-row operations return values in Fields(Retrieve) column order.
+		values := valuesForScan(t, m, tidal.Retrieve)
+		require.Equal(t, []any{uid, "/v1/items", other, seen, created, modified}, values)
+	})
+
+	t.Run("UpdateOverlay", func(t *testing.T) {
+		// Params(Update) overlays Create — only update columns appear, in Fields(Update) order.
+		updated := modified.Add(24 * time.Hour)
+		m.Modified = updated
+		values := valuesForScan(t, m, tidal.Update)
+		require.Equal(t, []any{uid, "/v1/items", updated}, values)
+	})
+
+	t.Run("MissingParamFails", func(t *testing.T) {
+		// A column in Fields with no matching Params entry is a model bug; helper must fail.
+		cap := &fatalCapture{T: t}
+		valuesForScan(cap, &brokenScanModel{}, tidal.Retrieve)
+		require.Contains(t, cap.msg, `missing value for Fields(Retrieve) entry "missing_col"`)
+	})
+}
+
+//============================================================================
+// modelID
+//============================================================================
+
+// Verifies [modelID] reads the primary key from Params(Create).
+func TestModelID(t *testing.T) {
+	t.Run("Found", func(t *testing.T) {
+		uid := ulid.MustParse("01KTESYNDPVTRWK05N2TXFKGQZ")
+		m := &scanHelperModel{BaseModel: tidal.BaseModel{ID: uid}}
+		arg := modelID(t, m)
+		require.Equal(t, "id", arg.Name)
+		require.Equal(t, uid, arg.Value)
+	})
+
+	t.Run("MissingFails", func(t *testing.T) {
+		// Models without id in Params(Create) cannot drive Retrieve/List/Update/Delete.
+		cap := &fatalCapture{T: t}
+		modelID(cap, noIDModel{})
+		require.Contains(t, cap.msg, "does not expose id in Params(Create)")
+	})
+}
+
+//============================================================================
+// fieldByColumn
+//============================================================================
+
+// Verifies [fieldByColumn] maps database column names (snake_case) back to struct fields,
+// including embedded [tidal.BaseModel] and acronym fields like URLPath → url_path.
+func TestFieldByColumn(t *testing.T) {
+	uid := ulid.MustParse("01KTESYNDPVTRWK05N2TXFKGQZ")
+	m := &scanHelperModel{
+		BaseModel: tidal.BaseModel{ID: uid},
+		URLPath:   "/x",
+		UserID:    uid,
+	}
+
+	v := reflect.ValueOf(m).Elem()
+
+	fv, ok := fieldByColumn(t, v, "url_path")
+	require.True(t, ok)
+	require.Equal(t, "/x", fv.String())
+
+	fv, ok = fieldByColumn(t, v, "id")
+	require.True(t, ok)
+	require.Equal(t, uid, fv.Interface())
+
+	_, ok = fieldByColumn(t, v, "no_such_column")
+	require.False(t, ok)
+}
+
+//============================================================================
+// equalListFields
+//============================================================================
+
+// Verifies [equalListFields] compares only the Fields(List) column subset, ignoring
+// columns that List Scan does not populate (e.g. last_seen on [scanHelperModel]).
+func TestEqualListFields(t *testing.T) {
+	uid := ulid.MustParse("01KTESYNDPVTRWK05N2TXFKGQZ")
+	other := ulid.MustParse("01KTESYNDPVTRWK05N2TXFKGQ0")
+
+	a := &scanHelperModel{
+		BaseModel: tidal.BaseModel{ID: uid},
+		URLPath:   "/a",
+		UserID:    other,
+		LastSeen:  sql.NullTime{Valid: true, Time: time.Now()},
+	}
+	b := &scanHelperModel{
+		BaseModel: tidal.BaseModel{ID: uid},
+		URLPath:   "/a",
+		UserID:    other,
+	}
+
+	require.True(t, equalListFields(t, a, b, a.Fields(tidal.List)))
+	require.False(t, equalListFields(t, a, &scanHelperModel{URLPath: "/b", UserID: other}, a.Fields(tidal.List)))
+}
+
+//============================================================================
+// mockScanner
+//============================================================================
+
+// Verifies [mockScanner] satisfies the [tidal.Scanner] contract used by the Scan
+// conformance phase.
+func TestMockScanner(t *testing.T) {
+	uid := ulid.MustParse("01KTESYNDPVTRWK05N2TXFKGQZ")
+	values := []any{uid, "/path", uid}
+
+	t.Run("HappyPath", func(t *testing.T) {
+		got := &scanHelperModel{}
+		require.NoError(t, got.Scan(tidal.List, &mockScanner{values: values}))
+		require.Equal(t, uid, got.ID)
+		require.Equal(t, "/path", got.URLPath)
+		require.Equal(t, uid, got.UserID)
+	})
+
+	t.Run("CountMismatch", func(t *testing.T) {
+		// Destination count must match Fields(op) length — same rule as *sql.Rows.Scan.
+		got := &scanHelperModel{}
+		err := got.Scan(tidal.List, &mockScanner{values: values[:1]})
+		require.ErrorContains(t, err, "expected 1 destinations, got 3")
+	})
+
+	t.Run("NilValue", func(t *testing.T) {
+		// nil in the fake row represents a SQL NULL and zeroes the destination.
+		var s string
+		require.NoError(t, (&mockScanner{values: []any{nil}}).Scan(&s))
+		require.Empty(t, s)
+	})
+}
+
+//============================================================================
+// Test Helpers
+//============================================================================
+
+// fatalCapture records Fatalf/Fatal without stopping the test runner, so negative-path
+// helper tests can assert on the failure message.
+type fatalCapture struct {
+	*testing.T
+	msg string
+}
+
+func (f *fatalCapture) Fatal(args ...any) {
+	f.msg = fmt.Sprint(args...)
+}
+
+func (f *fatalCapture) Fatalf(format string, args ...any) {
+	f.msg = fmt.Sprintf(format, args...)
+}
+
+//============================================================================
+// Test Models
+//============================================================================
+
+// scanHelperModel exercises acronym column naming (URLPath → url_path) and embedded
+// BaseModel fields. Not used against a real database.
+type scanHelperModel struct {
+	tidal.BaseModel
+	URLPath  string
+	UserID   ulid.ULID
+	LastSeen sql.NullTime
+}
+
+var _ tidal.Model = (*scanHelperModel)(nil)
+
+func (m *scanHelperModel) Fields(op tidal.Operation) []string {
+	switch op {
+	case tidal.List:
+		return []string{"id", "url_path", "user_id"}
+	case tidal.Update:
+		return []string{"id", "url_path", "modified"}
+	default:
+		return []string{"id", "url_path", "user_id", "last_seen", "created", "modified"}
+	}
+}
+
+func (m *scanHelperModel) Params(op tidal.Operation) []sql.NamedArg {
+	switch op {
+	case tidal.Update:
+		return []sql.NamedArg{
+			sql.Named("id", m.ID),
+			sql.Named("url_path", m.URLPath),
+			sql.Named("modified", m.Modified),
+		}
+	default:
+		return []sql.NamedArg{
+			sql.Named("id", m.ID),
+			sql.Named("url_path", m.URLPath),
+			sql.Named("user_id", m.UserID),
+			sql.Named("last_seen", m.LastSeen),
+			sql.Named("created", m.Created),
+			sql.Named("modified", m.Modified),
+		}
+	}
+}
+
+func (m *scanHelperModel) Scan(op tidal.Operation, s tidal.Scanner) error {
+	switch op {
+	case tidal.List:
+		return s.Scan(&m.ID, &m.URLPath, &m.UserID)
+	case tidal.Update:
+		return s.Scan(&m.ID, &m.URLPath, &m.Modified)
+	default:
+		return s.Scan(&m.ID, &m.URLPath, &m.UserID, &m.LastSeen, &m.Created, &m.Modified)
+	}
+}
+
+// noIDModel has no id in Params(Create) — used to test [modelID] failure path.
+type noIDModel struct{}
+
+func (noIDModel) Fields(tidal.Operation) []string { return []string{"id"} }
+func (noIDModel) Params(tidal.Operation) []sql.NamedArg {
+	return []sql.NamedArg{sql.Named("name", "x")}
+}
+func (noIDModel) Scan(tidal.Operation, tidal.Scanner) error { return nil }
+
+// brokenScanModel declares a Fields column with no Params value — used to test
+// [valuesForScan] failure path.
+type brokenScanModel struct {
+	tidal.BaseModel
+}
+
+func (brokenScanModel) Fields(tidal.Operation) []string { return []string{"id", "missing_col"} }
+func (brokenScanModel) Params(tidal.Operation) []sql.NamedArg {
+	return []sql.NamedArg{sql.Named("id", ulid.ULID{})}
+}
+func (brokenScanModel) Scan(tidal.Operation, tidal.Scanner) error { return nil }

--- a/suite/postgres.go
+++ b/suite/postgres.go
@@ -6,7 +6,7 @@ import (
 	"errors"
 	"fmt"
 
-	_ "github.com/lib/pq"
+	"go.rtnl.ai/tidal"
 	"go.rtnl.ai/x/dsn"
 	"go.rtnl.ai/x/randstr"
 )
@@ -55,33 +55,6 @@ func (p *PostgresProvider) ResolveDSN(databaseURL string) (_ *dsn.DSN, err error
 	return p.dsn, nil
 }
 
-func (p *PostgresProvider) Connect(ctx context.Context, uri *dsn.DSN) (db *sql.DB, err error) {
-	if uri.Provider != dsn.Postgres {
-		return nil, errors.Join(ErrInvalidProvider, ErrPostgresRequired)
-	}
-
-	connStr, pgopts, err := dsn.PGConnectionOptions(uri, nil)
-	if err != nil {
-		return nil, fmt.Errorf("could not get postgres connection options: %w", err)
-	}
-
-	if db, err = sql.Open("postgres", connStr); err != nil {
-		return nil, fmt.Errorf("could not open postgres connection: %w", err)
-	}
-
-	// Apply the connection options.
-	db.SetMaxIdleConns(pgopts.MaxIdleConns)
-	db.SetMaxOpenConns(pgopts.MaxOpenConns)
-	db.SetConnMaxLifetime(pgopts.ConnMaxLifetime)
-	db.SetConnMaxIdleTime(pgopts.ConnMaxIdleTime)
-
-	if err = db.PingContext(ctx); err != nil {
-		return nil, fmt.Errorf("could not ping database: %w", err)
-	}
-
-	return db, nil
-}
-
 func (p *PostgresProvider) CreateDB(ctx context.Context, uri *dsn.DSN) (_ *dsn.DSN, err error) {
 	// If a non-postgres database is specified then return the original DSN.
 	if uri.Path != "postgres" {
@@ -94,22 +67,19 @@ func (p *PostgresProvider) CreateDB(ctx context.Context, uri *dsn.DSN) (_ *dsn.D
 	p.dsn.Path = "tidal_test_" + randstr.AlphaLower(5) // databases in PG must be lower case
 
 	// Create a new database.
-	var db *sql.DB
-	if db, err = p.Connect(ctx, p.admin); err != nil {
+	var admin *tidal.DB
+	if admin, err = tidal.Open(ctx, p.admin); err != nil {
 		return nil, fmt.Errorf("could not connect to admin database: %w", err)
 	}
+	defer admin.Close()
 
 	stmt := "CREATE DATABASE " + p.dsn.Path
 	if p.admin.User != nil && p.admin.User.Username != "" {
 		stmt += " WITH OWNER " + p.admin.User.Username
 	}
 
-	if _, err = db.ExecContext(ctx, stmt); err != nil {
+	if _, err = admin.ExecContext(ctx, stmt); err != nil {
 		return nil, fmt.Errorf("could not create database: %w", err)
-	}
-
-	if err = db.Close(); err != nil {
-		return nil, fmt.Errorf("could not close database connection: %w", err)
 	}
 
 	return p.dsn, nil
@@ -117,17 +87,14 @@ func (p *PostgresProvider) CreateDB(ctx context.Context, uri *dsn.DSN) (_ *dsn.D
 
 func (p *PostgresProvider) DropDB(ctx context.Context, uri *dsn.DSN) (err error) {
 	if p.admin != nil && p.dsn != nil {
-		var db *sql.DB
-		if db, err = p.Connect(ctx, p.admin); err != nil {
+		var admin *tidal.DB
+		if admin, err = tidal.Open(ctx, p.admin); err != nil {
 			return fmt.Errorf("could not connect to admin database: %w", err)
 		}
+		defer admin.Close()
 
-		if _, err = db.ExecContext(ctx, "DROP DATABASE "+p.dsn.Path); err != nil {
+		if _, err = admin.ExecContext(ctx, "DROP DATABASE "+p.dsn.Path); err != nil {
 			return fmt.Errorf("could not drop database: %w", err)
-		}
-
-		if err = db.Close(); err != nil {
-			return fmt.Errorf("could not close database connection: %w", err)
 		}
 
 		p.admin = nil

--- a/suite/provider.go
+++ b/suite/provider.go
@@ -9,7 +9,7 @@ import (
 
 // A database provider is used to power a database test suite. The provider is meant to
 // implement database-specific functionality for the test suite, e.g. different SQL
-// syntaxes, different query patterns, etc.
+// syntaxes, different query patterns, etc. Use [tidal.Open] to connect to the database.
 type Provider interface {
 	// Resolve DSN must return a DSN for the database that allows connections while
 	// tests are running (possible in parallel with other test suites). It should
@@ -21,9 +21,6 @@ type Provider interface {
 	// CreateDB is called first to create the database using a management connection.
 	// If CreateDB creates a new DSN connection, it should return the new DSN.
 	CreateDB(ctx context.Context, uri *dsn.DSN) (*dsn.DSN, error)
-
-	// Connect is called to connect to the actual test database.
-	Connect(ctx context.Context, uri *dsn.DSN) (*sql.DB, error)
 
 	// DropDB is called after Close() to drop the database using a management connection.
 	DropDB(ctx context.Context, uri *dsn.DSN) error

--- a/suite/sqlite.go
+++ b/suite/sqlite.go
@@ -9,8 +9,6 @@ import (
 	"path/filepath"
 
 	"go.rtnl.ai/x/dsn"
-
-	_ "github.com/mattn/go-sqlite3"
 )
 
 type SQLiteSuite struct {
@@ -58,22 +56,6 @@ func (p *SQLiteProvider) ResolveDSN(databaseURL string) (_ *dsn.DSN, err error) 
 		}
 	}
 	return p.dsn, nil
-}
-
-func (p *SQLiteProvider) Connect(ctx context.Context, uri *dsn.DSN) (db *sql.DB, err error) {
-	if uri.Provider != dsn.SQLite3 {
-		return nil, errors.Join(ErrInvalidProvider, ErrSqliteRequired)
-	}
-
-	if db, err = sql.Open("sqlite3", uri.Path); err != nil {
-		return nil, fmt.Errorf("could not connect to database: %w", err)
-	}
-
-	if err = db.PingContext(ctx); err != nil {
-		return nil, fmt.Errorf("could not ping database: %w", err)
-	}
-
-	return db, nil
 }
 
 func (p *SQLiteProvider) CreateDB(ctx context.Context, uri *dsn.DSN) (*dsn.DSN, error) {

--- a/suite/suite.go
+++ b/suite/suite.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/suite"
+	"go.rtnl.ai/tidal"
 	"go.rtnl.ai/x/dsn"
 )
 
@@ -39,7 +40,7 @@ func Run(t *testing.T, s suite.TestingSuite) {
 type DatabaseSuite struct {
 	suite.Suite
 	Provider
-	*sql.DB
+	*tidal.DB // use DatabaseSuite.DB.DB to access the underlying sql.DB
 
 	DatabaseURL string
 	Migrations  Migrations
@@ -85,7 +86,7 @@ func (s *DatabaseSuite) SetupSuite() {
 
 	// Step three: connect to the database.
 	s.T().Logf("connecting to database: %s", s.dsn.String())
-	if s.DB, err = s.Connect(ctx, s.dsn); err != nil {
+	if s.DB, err = tidal.Open(ctx, s.dsn); err != nil {
 		s.T().Fatalf("failed to connect to database: %s", err.Error())
 		return
 	}
@@ -93,7 +94,7 @@ func (s *DatabaseSuite) SetupSuite() {
 	// Step four: apply the migrations if there are any.
 	if s.Migrations != nil {
 		s.T().Log("applying migrations")
-		if err = s.Migrations.Apply(ctx, s.dsn.Provider, s.DB, "test"); err != nil {
+		if err = s.Migrations.Apply(ctx, s.dsn.Provider, s.DB.DB, "test"); err != nil {
 			s.T().Fatalf("failed to apply migrations: %s", err.Error())
 			return
 		}
@@ -214,7 +215,7 @@ func (s *DatabaseSuite) context() (context.Context, context.CancelFunc) {
 // Starts a new transaction on the database with the current context. Callers
 // must ensure that the transaction is rolled back or committed. Takes a read
 // lock on mu.
-func (s *DatabaseSuite) BeginTx(opts *sql.TxOptions) *sql.Tx {
+func (s *DatabaseSuite) BeginTx(opts *sql.TxOptions) tidal.Tx {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
 
@@ -233,7 +234,7 @@ func (s *DatabaseSuite) Migrate() {
 		ctx, cancel := s.context()
 		defer cancel()
 
-		s.Require().NoError(s.Migrations.Apply(ctx, s.dsn.Provider, s.DB, "test"), "failed to apply migrations")
+		s.Require().NoError(s.Migrations.Apply(ctx, s.dsn.Provider, s.DB.DB, "test"), "failed to apply migrations")
 	} else {
 		// NOTE: this is not necessarily an error; for example a test suite may not
 		// use these fields for every test.
@@ -258,7 +259,7 @@ func (s *DatabaseSuite) DropTables() {
 		ctx, cancel := s.context()
 		defer cancel()
 
-		s.Require().NoError(s.Provider.DropTables(ctx, s.DB), "failed to drop tables")
+		s.Require().NoError(s.Provider.DropTables(ctx, s.DB.DB), "failed to drop tables")
 	} else {
 		s.T().Log("cannot drop tables because s.DB is nil")
 	}
@@ -270,7 +271,7 @@ func (s *DatabaseSuite) TruncateTables() {
 		ctx, cancel := s.context()
 		defer cancel()
 
-		s.Require().NoError(s.Provider.TruncateTables(ctx, s.DB), "failed to truncate tables")
+		s.Require().NoError(s.Provider.TruncateTables(ctx, s.DB.DB), "failed to truncate tables")
 	} else {
 		s.T().Log("cannot truncate tables because s.DB is nil")
 	}

--- a/tidal.go
+++ b/tidal.go
@@ -16,12 +16,15 @@ type QuerySet struct {
 	Delete   string // Must not contain a WHERE clause.
 }
 
+// CRUD runs create, read, update, delete, and list operations for a [Model] type.
+// Build one with [New] and call its methods inside a [Tx].
 type CRUD[M Model] struct {
 	Queries QuerySet
 	fields  map[Operation][]string
 	params  map[Operation][]string
 }
 
+// New builds a CRUD store for table using the [Model] type M to derive SQL and parameters.
 func New[M Model](table string) *CRUD[M] {
 	c := &CRUD[M]{
 		fields: make(map[Operation][]string),
@@ -52,6 +55,7 @@ func New[M Model](table string) *CRUD[M] {
 	return c
 }
 
+// List returns a [Cursor] over rows matching filter. Pass nil for no filter clause.
 func (c *CRUD[M]) List(tx Tx, filter ListFilter) (_ Cursor[M], err error) {
 	var params []sql.NamedArg
 	query := c.Queries.List
@@ -70,6 +74,7 @@ func (c *CRUD[M]) List(tx Tx, filter ListFilter) (_ Cursor[M], err error) {
 	return Rows[M](tx, rows), nil
 }
 
+// Create inserts m. [Preparer] and [Validator] hooks run when implemented.
 func (c *CRUD[M]) Create(tx Tx, m M) (result sql.Result, err error) {
 	if prepare, ok := any(m).(Preparer); ok {
 		prepare.Prepare(Create)
@@ -82,6 +87,7 @@ func (c *CRUD[M]) Create(tx Tx, m M) (result sql.Result, err error) {
 	return tx.Exec(c.Queries.Create, m.Params(Create)...)
 }
 
+// Retrieve loads the row where the id column equals id.
 func (c *CRUD[M]) Retrieve(tx Tx, id sql.NamedArg) (m M, err error) {
 	m = Make[M]()
 	query := c.Queries.Retrieve + id.Name + " = :" + id.Name
@@ -91,6 +97,7 @@ func (c *CRUD[M]) Retrieve(tx Tx, id sql.NamedArg) (m M, err error) {
 	return m, nil
 }
 
+// Update saves m. Returns [ErrNotFound] when no row matches m's id.
 func (c *CRUD[M]) Update(tx Tx, m M) (err error) {
 	if prepare, ok := any(m).(Preparer); ok {
 		prepare.Prepare(Update)
@@ -110,11 +117,13 @@ func (c *CRUD[M]) Update(tx Tx, m M) (err error) {
 	return nil
 }
 
+// Delete removes the row where the id column equals id.
 func (c *CRUD[M]) Delete(tx Tx, id sql.NamedArg) (result sql.Result, err error) {
 	query := c.Queries.Delete + id.Name + " = :" + id.Name
 	return tx.Exec(query, id)
 }
 
+// Fields returns the column names for op, cached after the first call.
 func (c *CRUD[M]) Fields(op Operation) (fields []string) {
 	fields, ok := c.fields[op]
 	if !ok {
@@ -125,6 +134,7 @@ func (c *CRUD[M]) Fields(op Operation) (fields []string) {
 	return fields
 }
 
+// Params returns column names and :name placeholders for op.
 func (c *CRUD[M]) Params(op Operation) (fields []string, placeholders []string) {
 	names, ok := c.params[op]
 	if !ok {
@@ -143,19 +153,23 @@ func (c *CRUD[M]) Params(op Operation) (fields []string, placeholders []string) 
 	return names, placeholders
 }
 
+// ListQuery builds the SELECT used by [CRUD.List].
 func (c *CRUD[M]) ListQuery(table string) string {
 	return fmt.Sprintf("SELECT %s FROM %s", strings.Join(c.Fields(List), ", "), table)
 }
 
+// CreateQuery builds the INSERT used by [CRUD.Create].
 func (c *CRUD[M]) CreateQuery(table string) string {
 	fields, placeholders := c.Params(Create)
 	return fmt.Sprintf("INSERT INTO %s (%s) VALUES (%s)", table, strings.Join(fields, ", "), strings.Join(placeholders, ", "))
 }
 
+// RetrieveQuery builds the SELECT prefix used by [CRUD.Retrieve] (caller appends the id predicate).
 func (c *CRUD[M]) RetrieveQuery(table string) string {
 	return fmt.Sprintf("SELECT %s FROM %s WHERE ", strings.Join(c.Fields(Retrieve), ", "), table)
 }
 
+// UpdateQuery builds the UPDATE used by [CRUD.Update].
 func (c *CRUD[M]) UpdateQuery(table string, fieldID string) string {
 	fields, placeholders := c.Params(Update)
 	setters := make([]string, 0, len(fields))
@@ -168,6 +182,7 @@ func (c *CRUD[M]) UpdateQuery(table string, fieldID string) string {
 	return fmt.Sprintf("UPDATE %s SET %s WHERE %s=:%s", table, strings.Join(setters, ", "), fieldID, fieldID)
 }
 
+// DeleteQuery builds the DELETE prefix used by [CRUD.Delete] (caller appends the id predicate).
 func (c *CRUD[M]) DeleteQuery(table string) string {
 	return fmt.Sprintf("DELETE FROM %s WHERE ", table)
 }

--- a/tidal.go
+++ b/tidal.go
@@ -16,15 +16,32 @@ type QuerySet struct {
 	Delete   string // Must not contain a WHERE clause.
 }
 
-// TODO: the CRUD struct needs to know the PlaceholderType to use for the query.
 type CRUD[M Model] struct {
 	Queries QuerySet
-	// params  map[Operation]Params // TODO: unused for now
-	fields map[Operation][]string
+	fields  map[Operation][]string
+	params  map[Operation][]string
 }
 
 func New[M Model](table string) *CRUD[M] {
-	c := &CRUD[M]{}
+	c := &CRUD[M]{
+		fields: make(map[Operation][]string),
+		params: make(map[Operation][]string),
+	}
+
+	// Precompute the parameters for the all operations that have parameters.
+	for _, op := range []Operation{List, Create, Retrieve, Update, Delete} {
+		m := Make[M]()
+		ps := m.Params(op)
+		if len(ps) == 0 {
+			continue
+		}
+		names := make([]string, len(ps))
+		for i, p := range ps {
+			names[i] = p.Name
+		}
+		c.params[op] = names
+	}
+
 	c.Queries = QuerySet{
 		List:     c.ListQuery(table),
 		Create:   c.CreateQuery(table),
@@ -36,7 +53,6 @@ func New[M Model](table string) *CRUD[M] {
 }
 
 func (c *CRUD[M]) List(tx Tx, filter ListFilter) (_ Cursor[M], err error) {
-	// Add the filtering constraints to the query (if any).
 	var params []sql.NamedArg
 	query := c.Queries.List
 
@@ -51,7 +67,6 @@ func (c *CRUD[M]) List(tx Tx, filter ListFilter) (_ Cursor[M], err error) {
 	if rows, err = tx.Query(query, params...); err != nil {
 		return nil, err
 	}
-
 	return Rows[M](tx, rows), nil
 }
 
@@ -59,18 +74,12 @@ func (c *CRUD[M]) Create(tx Tx, m M) (result sql.Result, err error) {
 	if prepare, ok := any(m).(Preparer); ok {
 		prepare.Prepare(Create)
 	}
-
 	if validator, ok := any(m).(Validator); ok {
 		if err = validator.Validate(Create); err != nil {
 			return nil, err
 		}
 	}
-
-	if result, err = tx.Exec(c.Queries.Create, m.Params(Create)...); err != nil {
-		return nil, err
-	}
-
-	return result, nil
+	return tx.Exec(c.Queries.Create, m.Params(Create)...)
 }
 
 func (c *CRUD[M]) Retrieve(tx Tx, id sql.NamedArg) (m M, err error) {
@@ -86,18 +95,15 @@ func (c *CRUD[M]) Update(tx Tx, m M) (err error) {
 	if prepare, ok := any(m).(Preparer); ok {
 		prepare.Prepare(Update)
 	}
-
 	if validator, ok := any(m).(Validator); ok {
 		if err = validator.Validate(Update); err != nil {
 			return err
 		}
 	}
-
 	var result sql.Result
 	if result, err = tx.Exec(c.Queries.Update, m.Params(Update)...); err != nil {
 		return err
 	}
-
 	if nRows, _ := result.RowsAffected(); nRows == 0 {
 		return ErrNotFound
 	}
@@ -106,15 +112,12 @@ func (c *CRUD[M]) Update(tx Tx, m M) (err error) {
 
 func (c *CRUD[M]) Delete(tx Tx, id sql.NamedArg) (result sql.Result, err error) {
 	query := c.Queries.Delete + id.Name + " = :" + id.Name
-	if result, err = tx.Exec(query, id); err != nil {
-		return nil, err
-	}
-	return result, nil
+	return tx.Exec(query, id)
 }
 
 func (c *CRUD[M]) Fields(op Operation) (fields []string) {
-	var ok bool
-	if fields, ok = c.fields[op]; !ok {
+	fields, ok := c.fields[op]
+	if !ok {
 		m := Make[M]()
 		fields = m.Fields(op)
 		c.fields[op] = fields
@@ -122,19 +125,22 @@ func (c *CRUD[M]) Fields(op Operation) (fields []string) {
 	return fields
 }
 
-// TODO: cache so that we don't have to create a new model and params for every call.
 func (c *CRUD[M]) Params(op Operation) (fields []string, placeholders []string) {
-	m := Make[M]()
-	params := m.Params(op)
-
-	fields = make([]string, len(params))
-	placeholders = make([]string, len(params))
-
-	for i, param := range params {
-		fields[i] = param.Name
-		placeholders[i] = ":" + param.Name
+	names, ok := c.params[op]
+	if !ok {
+		m := Make[M]()
+		ps := m.Params(op)
+		names = make([]string, len(ps))
+		for i, p := range ps {
+			names[i] = p.Name
+		}
+		c.params[op] = names
 	}
-	return fields, placeholders
+	placeholders = make([]string, len(names))
+	for i, name := range names {
+		placeholders[i] = ":" + name
+	}
+	return names, placeholders
 }
 
 func (c *CRUD[M]) ListQuery(table string) string {
@@ -153,14 +159,12 @@ func (c *CRUD[M]) RetrieveQuery(table string) string {
 func (c *CRUD[M]) UpdateQuery(table string, fieldID string) string {
 	fields, placeholders := c.Params(Update)
 	setters := make([]string, 0, len(fields))
-
 	for i, field := range fields {
 		if field == fieldID {
 			continue
 		}
 		setters = append(setters, fmt.Sprintf("%s=%s", field, placeholders[i]))
 	}
-
 	return fmt.Sprintf("UPDATE %s SET %s WHERE %s=:%s", table, strings.Join(setters, ", "), fieldID, fieldID)
 }
 

--- a/tidal_test.go
+++ b/tidal_test.go
@@ -1,22 +1,30 @@
 package tidal_test
 
 import (
+	"database/sql"
 	"embed"
+	"fmt"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"go.rtnl.ai/tidal/migrations"
 	"go.rtnl.ai/tidal/suite"
+	"go.rtnl.ai/ulid"
 )
 
 type TidalTestSuite struct {
 	suite.DatabaseSuite
 }
 
+//============================================================================
+// Postgres Tests
+//============================================================================
+
 //go:embed testdata/postgres
 var postgresFS embed.FS
 
-func TestTidalPostgres(t *testing.T) {
+func TestPostgres(t *testing.T) {
 	var err error
 	s := &TidalTestSuite{}
 	s.Provider = &suite.PostgresProvider{}
@@ -26,14 +34,17 @@ func TestTidalPostgres(t *testing.T) {
 	_, err = s.ResolveDSN("")
 	require.NoError(t, err, "could not resolve postgres DSN")
 
-	// Run the tests
 	suite.Run(t, s)
 }
+
+//============================================================================
+// SQLite Tests
+//============================================================================
 
 //go:embed testdata/sqlite
 var sqliteFS embed.FS
 
-func TestSQLite(t *testing.T) {
+func TestSQLite3(t *testing.T) {
 	var err error
 	s := &TidalTestSuite{}
 	s.Provider = &suite.SQLiteProvider{}
@@ -43,6 +54,30 @@ func TestSQLite(t *testing.T) {
 	_, err = s.ResolveDSN("")
 	require.NoError(t, err, "could not resolve sqlite DSN")
 
-	// Run the tests
 	suite.Run(t, s)
+}
+
+//============================================================================
+// CRUD Conformance Tests Testing (User Model)
+//============================================================================
+
+func (s *TidalTestSuite) TestUserCRUDConformance() {
+	suite.ModelConformsCRUD(&s.DatabaseSuite, suite.CRUDConformance[*User]{
+		Table:  "users",
+		Create: newConformanceUser,
+		Update: func(u *User) {
+			u.Name = "Updated Conformance User"
+		},
+	})
+}
+
+func newConformanceUser() *User {
+	return &User{
+		Name:     "Conformance User",
+		DoB:      sql.NullTime{Valid: true, Time: time.Date(1990, 1, 1, 0, 0, 0, 0, time.UTC)},
+		Email:    fmt.Sprintf("conformance-%s@example.com", ulid.MakeSecure().String()),
+		Password: "test-password",
+		Verified: true,
+		LastSeen: sql.NullTime{Valid: true, Time: time.Now().Add(-1 * time.Hour)},
+	}
 }

--- a/tidal_test.go
+++ b/tidal_test.go
@@ -62,7 +62,7 @@ func TestSQLite3(t *testing.T) {
 //============================================================================
 
 func (s *TidalTestSuite) TestUserCRUDConformance() {
-	suite.ModelConformsCRUD(&s.DatabaseSuite, suite.CRUDConformance[*User]{
+	suite.ConformsCRUD(&s.DatabaseSuite, suite.CRUDConformance[*User]{
 		Table:  "users",
 		Create: newConformanceUser,
 		Update: func(u *User) {

--- a/tx.go
+++ b/tx.go
@@ -4,43 +4,54 @@ import (
 	"database/sql"
 )
 
+// Tx is a database transaction that accepts canonical :name SQL and named arguments.
 type Tx interface {
 	Commit() error
 	Rollback() error
 
 	Query(query string, args ...sql.NamedArg) (*sql.Rows, error)
-	QueryRow(query string, args ...sql.NamedArg) *sql.Row
+	QueryRow(query string, args ...sql.NamedArg) *Row
 	Exec(query string, args ...sql.NamedArg) (sql.Result, error)
 }
 
-func Wrap(tx *sql.Tx) Tx {
+// Wraps a sql.Tx and returns a Tx that rewrites placeholders for the given DSN
+// provider (for example [dsn.Postgres] or [dsn.SQLite3]).
+func newTxn(tx *sql.Tx, provider string) Tx {
 	return &Txn{
-		Tx: tx,
+		Tx:          tx,
+		placeholder: PlaceholderFor(provider),
 	}
 }
 
-// Txn is a wrapper around a sql.Tx that implements the Tx interface by requiring
-// sql.NamedArgs rather than any values being passed as variadic arguments.
+// Txn wraps sql.Tx and binds queries through QueryParams before execution.
 type Txn struct {
 	*sql.Tx
+	placeholder PlaceholderType
 }
 
+// Exec runs a query after rewriting placeholders for the configured driver.
 func (t *Txn) Exec(query string, args ...sql.NamedArg) (sql.Result, error) {
-	return t.Tx.Exec(query, QueryArgs(args)...)
-}
-
-func (t *Txn) Query(query string, args ...sql.NamedArg) (*sql.Rows, error) {
-	return t.Tx.Query(query, QueryArgs(args)...)
-}
-
-func (t *Txn) QueryRow(query string, args ...sql.NamedArg) *sql.Row {
-	return t.Tx.QueryRow(query, QueryArgs(args)...)
-}
-
-func QueryArgs(args []sql.NamedArg) []any {
-	out := make([]any, len(args))
-	for i, arg := range args {
-		out[i] = arg.Value
+	p, err := QueryParams(query, args, t.placeholder)
+	if err != nil {
+		return nil, err
 	}
-	return out
+	return t.Tx.Exec(p.SQL(), p.Args()...)
+}
+
+// Query runs a query after rewriting placeholders for the configured driver.
+func (t *Txn) Query(query string, args ...sql.NamedArg) (*sql.Rows, error) {
+	p, err := QueryParams(query, args, t.placeholder)
+	if err != nil {
+		return nil, err
+	}
+	return t.Tx.Query(p.SQL(), p.Args()...)
+}
+
+// QueryRow runs a query after rewriting placeholders for the configured driver.
+func (t *Txn) QueryRow(query string, args ...sql.NamedArg) *Row {
+	p, err := QueryParams(query, args, t.placeholder)
+	if err != nil {
+		return &Row{err: err}
+	}
+	return &Row{row: t.Tx.QueryRow(p.SQL(), p.Args()...)}
 }

--- a/tx_test.go
+++ b/tx_test.go
@@ -1,0 +1,40 @@
+package tidal_test
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.rtnl.ai/tidal"
+	"go.rtnl.ai/x/dsn"
+
+	_ "github.com/mattn/go-sqlite3"
+)
+
+//============================================================================
+// Tx Bind Errors
+//============================================================================
+
+// Unlike [tidal.Row] (deferred to Scan), Exec and Query return bind errors immediately
+// when the placeholder type is unsupported.
+func TestTxnBindErrors(t *testing.T) {
+	db, err := sql.Open("sqlite3", ":memory:")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = db.Close() })
+
+	tidalDB := tidal.Wrap(db, &dsn.DSN{Provider: "mysql"})
+	tx, err := tidalDB.BeginTx(context.Background(), nil)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = tx.Rollback() })
+
+	t.Run("Exec", func(t *testing.T) {
+		_, err := tx.Exec("SELECT :x", sql.Named("x", 1))
+		require.ErrorIs(t, err, tidal.ErrUnsupportedPlaceholder)
+	})
+
+	t.Run("Query", func(t *testing.T) {
+		_, err := tx.Query("SELECT :x", sql.Named("x", 1))
+		require.ErrorIs(t, err, tidal.ErrUnsupportedPlaceholder)
+	})
+}


### PR DESCRIPTION
### Scope of changes

Added a conformance suite for the model CRUD operations. When I added this, I found that a bunch of code was buggy or just plain missing (query rewriting was important for this conformance test) and had to implement tons of extra stuff to make everything work nicely and not be buggy or missing important features. I added tons of testing where necessary to ensure it works.

Basically, the only things we have left in `tidal` is to do pagination and WHERE clauses in Filter, and then any future improvements we want past the initial version of this library, like code generation or whatever else. This library should be in a good place to be used now and should be tagged with `v0.1.0` after this, probably.

_Note: I cannot guarantee that in the wild nothing will be buggy; I tried to catch as many cases of stuff I could, and for the conformance testing and rewriting I tried to do the string building and stuff properly, but there likely will be some edge cases that fail as we roll out implementations of this. Specifically, we should be careful with field names on models when doing the conformance testing, as some field names could be mis-translated from CamelCase into snake_case for part of the conformance suite._

#### Itemized features/changes:

- **Database connection layer** — Added `tidal.Open`, `tidal.Wrap`, and `*tidal.DB` for connecting via `go.rtnl.ai/x/dsn` DSNs (SQLite3 + Postgres). Applies Postgres pool settings, pings on connect, and returns transactions with the right placeholder style for the provider.

- **Canonical `:name` SQL with driver rewriting** — Replaced the old stub `QueryParams` with a real query rewriter that scans SQL left-to-right, binds `sql.NamedArg` values, and emits driver-specific placeholders (`$1`, `$2`, … for Postgres; `?` for SQLite). Handles repeated names, `::type` casts, and missing-argument errors (`MissingArgumentError`).

- **Transaction API wired through rewriting** — `DB.BeginTx` returns `tidal.Tx`; `Exec` / `Query` / `QueryRow` all bind through `QueryParams`. `PlaceholderFor` maps DSN provider → placeholder style.

- **`tidal.Row`** — `QueryRow` now returns `*Row` so placeholder-binding errors surface at `Scan` / `Err` instead of being lost at call time.

- **`Cursor.CloseRows()`** — Close the result set without rolling back the transaction (needed for SQLite, where open `sql.Rows` block writes in the same tx). `Close()` still rolls back.

- **CRUD param caching** — `tidal.New` precomputes and caches `Params` per operation; `Fields` / `Params` on `CRUD` avoid re-instantiating models on every call.

- **`ConformsCRUD` model conformance suite** (`go.rtnl.ai/tidal/suite`) — Three-phase test helper for `Model` implementations:
  1. **Shape** — `Fields` / `Params` alignment + non-empty generated SQL (no DB)
  2. **Scan** — fake row built from `Params`, exercised via `mockScanner` (no DB)
  3. **RoundTrip** — full create → retrieve → list → update → delete against the real suite DB (rolled back)

- **CamelCase ↔ snake_case mapping in conformance** — `fieldByColumn` / `columnName` with acronym, digit-boundary, and particle rules (`UserID`, `URLPath`, `DoB`, etc.) so list-field comparisons work without manual column maps.

- **Test suite uses `tidal.Open`** — `DatabaseSuite` holds `*tidal.DB`; `Provider.Connect` removed. Postgres admin create/drop uses `tidal.Open` instead of duplicated connect logic. `BeginTx` returns `tidal.Tx`.

- **Broad test coverage** — New/expanded tests for `QueryParams`, filters, CRUD error paths, list+filter, cursor lifecycle, `Row`, `Tx`, and the conformance suite itself (shape, scan, round-trip, column-name helpers).

- **README + package docs** — New Connecting and CRUD sections, `ConformsCRUD` usage guide, migrations examples updated for `tidal.Open` / `db.DB`, and `doc.go` for `tidal`, `fields`, and `migrations`.

Fixes SC-38936

### Estimated PR Size:

- [ ] Tiny
- [ ] Small
- [ ] Medium
- [x] Large
- [ ] Huge

### Acceptance criteria

Ensure the patterns are simple and the stuff I added/modified isn't garbage, basically.

### Author checklist

- [x] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ] I have updated the dependencies list
- [ ] I have added new test fixtures as needed to support added tests
- [x] I have added or updated the documentation
- [ ] I have run go generate to update generated code
- [x] Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.
- [ ] To the best of my ability, I believe that this PR represents a good solution to the specified problem and that it should be merged into the main code base.