### PR TITLE
[FIX] Postgres connections will return UTC by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,39 @@ sqlDB, _ := sql.Open("sqlite3", uri.Path)
 db := tidal.Wrap(sqlDB, uri)
 ```
 
+## Connection options
+
+Connection URLs are parsed by [`go.rtnl.ai/x/dsn`](https://pkg.go.dev/go.rtnl.ai/x/dsn). Query parameters become `DSN.Options` and are handled in one of three ways: consumed by tidal for pool or connection behavior, read from the DSN at runtime, or passed through to the driver unchanged. See the [dsn package docs](https://pkg.go.dev/go.rtnl.ai/x/dsn) for URL format and Postgres libpq parameters (`sslmode`, `connect_timeout`, and so on).
+
+### Shared
+
+| Option | Description |
+| --- | --- |
+| `readonly` | When `true`, [`DB.BeginTx`](https://pkg.go.dev/go.rtnl.ai/tidal#DB.BeginTx) defaults to read-only transactions and rejects writes. |
+
+### Postgres
+
+Tidal opens Postgres through [pgx](https://github.com/jackc/pgx) (`database/sql` stdlib driver).
+
+| Option | Description |
+| --- | --- |
+| `max_idle_conns` | `database/sql` pool setting (default `8`). Removed from the URL before connecting. |
+| `max_open_conns` | `database/sql` pool setting (default `16`). Removed from the URL before connecting. |
+| `conn_max_lifetime` | `database/sql` pool setting (default `1h`). Removed from the URL before connecting. |
+| `conn_max_idle_time` | `database/sql` pool setting (default `30m`). Removed from the URL before connecting. |
+
+All other query parameters are forwarded to Postgres as normal connection options — see [dsn](https://pkg.go.dev/go.rtnl.ai/x/dsn).
+
+On connect, tidal registers a pgx `timestamptz` codec so values scanned into `time.Time` use `time.UTC` as their location (the instant is unchanged). This matches lib/pq behavior and avoids local-timezone surprises in tests and equality checks. Not configurable via DSN yet.
+
+### SQLite3
+
+| Option | Description |
+| --- | --- |
+| `readonly` | Same as above. SQLite read-only mode is enforced at the transaction level. |
+
+The database file path comes from the DSN path (`sqlite3:///path/to/db.sqlite`). Tidal does not set SQLite pragmas on `Open`; run `PRAGMA foreign_keys = on` or `PRAGMA query_only = on` after connect in application code when you need them.
+
 ## CRUD
 
 Implement [`Model`](https://pkg.go.dev/go.rtnl.ai/tidal#Model) on your struct and embed [`BaseModel`](https://pkg.go.dev/go.rtnl.ai/tidal#BaseModel) for ULID ids and timestamps. Build a typed store with [`New`](https://pkg.go.dev/go.rtnl.ai/tidal#New) and run operations inside a transaction:

--- a/conn/conn_test.go
+++ b/conn/conn_test.go
@@ -1,0 +1,22 @@
+package conn_test
+
+import (
+	"go.rtnl.ai/tidal/suite"
+	"go.rtnl.ai/x/dsn"
+)
+
+type connSuite struct {
+	suite.DatabaseSuite
+}
+
+func (s *connSuite) requirePostgres() {
+	if s.DSN().Provider != dsn.Postgres {
+		s.T().Skip("postgres required")
+	}
+}
+
+func (s *connSuite) requireSQLite3() {
+	if s.DSN().Provider != dsn.SQLite3 {
+		s.T().Skip("sqlite3 required")
+	}
+}

--- a/conn/db.go
+++ b/conn/db.go
@@ -7,7 +7,6 @@ import (
 
 	"go.rtnl.ai/x/dsn"
 
-	_ "github.com/jackc/pgx/v5/stdlib"
 	_ "github.com/mattn/go-sqlite3"
 )
 
@@ -44,10 +43,28 @@ type DB struct {
 // to check liveness and connectivity. The database must be ready before calling
 // Open.
 func Open(ctx context.Context, uri *dsn.DSN) (*DB, error) {
-	sqlDB, err := open(ctx, uri)
+	var (
+		sqlDB *sql.DB
+		err   error
+	)
+
+	switch uri.Provider {
+	case dsn.SQLite3:
+		sqlDB, err = openSQLite3(ctx, uri)
+	case dsn.Postgres:
+		sqlDB, err = openPostgres(ctx, uri, nil)
+	default:
+		return nil, UnsupportedProvider(uri.Provider)
+	}
 	if err != nil {
 		return nil, err
 	}
+
+	if err := sqlDB.PingContext(ctx); err != nil {
+		_ = sqlDB.Close()
+		return nil, errors.Join(ErrPing, err)
+	}
+
 	return Wrap(sqlDB, uri), nil
 }
 
@@ -114,34 +131,4 @@ func (db *DB) WithTx(ctx context.Context, opts *sql.TxOptions, fn func(Tx) error
 // WithReadTx runs a function with a read-only transaction for this DB's provider.
 func (db *DB) WithReadTx(ctx context.Context, fn func(Tx) error) (err error) {
 	return db.WithTx(ctx, &sql.TxOptions{ReadOnly: true}, fn)
-}
-
-// Opens a new database connection to the database described by uri.
-func open(ctx context.Context, uri *dsn.DSN) (db *sql.DB, err error) {
-	switch uri.Provider {
-	case dsn.SQLite3:
-		if db, err = sql.Open("sqlite3", uri.Path); err != nil {
-			return nil, errors.Join(ErrConnect, err)
-		}
-	case dsn.Postgres:
-		connStr, pgopts, err := dsn.PGConnectionOptions(uri, nil)
-		if err != nil {
-			return nil, errors.Join(ErrConnectionOptions, err)
-		}
-		if db, err = sql.Open("pgx", connStr); err != nil {
-			return nil, errors.Join(ErrConnect, err)
-		}
-		db.SetMaxIdleConns(pgopts.MaxIdleConns)
-		db.SetMaxOpenConns(pgopts.MaxOpenConns)
-		db.SetConnMaxLifetime(pgopts.ConnMaxLifetime)
-		db.SetConnMaxIdleTime(pgopts.ConnMaxIdleTime)
-	default:
-		return nil, UnsupportedProvider(uri.Provider)
-	}
-
-	if err = db.PingContext(ctx); err != nil {
-		_ = db.Close()
-		return nil, errors.Join(ErrPing, err)
-	}
-	return db, nil
 }

--- a/conn/postgres.go
+++ b/conn/postgres.go
@@ -1,0 +1,45 @@
+package conn
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/jackc/pgx/v5/stdlib"
+	"go.rtnl.ai/x/dsn"
+)
+
+// Opens a Postgres connection using pgx and applies pool options from uri.
+func openPostgres(_ context.Context, uri *dsn.DSN, defaults map[string]string) (*sql.DB, error) {
+	connStr, pgopts, err := dsn.PGConnectionOptions(uri, defaults)
+	if err != nil {
+		return nil, errors.Join(ErrConnectionOptions, err)
+	}
+
+	cfg, err := pgx.ParseConfig(connStr)
+	if err != nil {
+		return nil, errors.Join(ErrConnectionOptions, err)
+	}
+
+	// TODO: allow the user to set this option in the future, for now we default to UTC times
+	db := stdlib.OpenDB(*cfg, stdlib.OptionAfterConnect(utcTimestamptzAfterConnect))
+
+	db.SetMaxIdleConns(pgopts.MaxIdleConns)
+	db.SetMaxOpenConns(pgopts.MaxOpenConns)
+	db.SetConnMaxLifetime(pgopts.ConnMaxLifetime)
+	db.SetConnMaxIdleTime(pgopts.ConnMaxIdleTime)
+	return db, nil
+}
+
+// Sets the time zone to UTC for the timestamptz type for pgx connections.
+func utcTimestamptzAfterConnect(ctx context.Context, conn *pgx.Conn) error {
+	conn.TypeMap().RegisterType(&pgtype.Type{
+		Name:  "timestamptz",
+		OID:   pgtype.TimestamptzOID,
+		Codec: &pgtype.TimestamptzCodec{ScanLocation: time.UTC},
+	})
+	return nil
+}

--- a/conn/postgres_test.go
+++ b/conn/postgres_test.go
@@ -19,6 +19,7 @@ func TestPostgres(t *testing.T) {
 	suite.Run(t, s)
 }
 
+// TestTimestamptzReturnsUTC tests that Postgres timestamptz values are returned as UTC.
 func (s *connSuite) TestTimestamptzReturnsUTC() {
 	s.requirePostgres()
 	require := s.Require()

--- a/conn/postgres_test.go
+++ b/conn/postgres_test.go
@@ -1,0 +1,76 @@
+package conn_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	"go.rtnl.ai/tidal/suite"
+)
+
+func TestPostgres(t *testing.T) {
+	s := &connSuite{}
+	s.Provider = &suite.PostgresProvider{}
+	s.Teardown = suite.TeardownNone
+
+	_, err := s.ResolveDSN("")
+	require.NoError(t, err, "could not resolve postgres DSN")
+
+	suite.Run(t, s)
+}
+
+func (s *connSuite) TestTimestamptzReturnsUTC() {
+	s.requirePostgres()
+	require := s.Require()
+	ctx := s.Context()
+
+	hst := time.FixedZone("HST", -10*60*60)
+
+	cases := []struct {
+		name     string
+		param    time.Time
+		expected time.Time
+	}{
+		{
+			name:     "UTC",
+			param:    time.Date(2025, 2, 14, 11, 21, 42, 0, time.UTC),
+			expected: time.Date(2025, 2, 14, 11, 21, 42, 0, time.UTC),
+		},
+		{
+			name:     "NonUTCInput",
+			param:    time.Date(2025, 2, 14, 1, 21, 42, 0, hst),
+			expected: time.Date(2025, 2, 14, 11, 21, 42, 0, time.UTC),
+		},
+		{
+			name:     "FixtureLiteral",
+			param:    time.Date(2025, 3, 4, 19, 9, 6, 0, time.UTC),
+			expected: time.Date(2025, 3, 4, 19, 9, 6, 0, time.UTC),
+		},
+		{
+			name:     "MicrosecondPrecision",
+			param:    time.Date(2024, 6, 1, 12, 0, 0, 123456000, time.UTC),
+			expected: time.Date(2024, 6, 1, 12, 0, 0, 123456000, time.UTC),
+		},
+	}
+
+	for _, tc := range cases {
+		s.Run(tc.name, func() {
+			var got time.Time
+			err := s.DB.QueryRowContext(ctx, "SELECT $1::timestamptz", tc.param).Scan(&got)
+			require.NoError(err)
+			require.Equal(time.UTC, got.Location())
+			require.True(got.Round(time.Microsecond).Equal(tc.expected.Round(time.Microsecond)))
+		})
+	}
+
+	s.Run("SQLLiteral", func() {
+		var got time.Time
+		err := s.DB.QueryRowContext(ctx, "SELECT '2025-02-14T11:21:42+00:00'::timestamptz").Scan(&got)
+		require.NoError(err)
+		require.Equal(time.UTC, got.Location())
+		require.Equal(
+			time.Date(2025, 2, 14, 11, 21, 42, 0, time.UTC),
+			got,
+		)
+	})
+}

--- a/conn/sqlite3.go
+++ b/conn/sqlite3.go
@@ -1,0 +1,17 @@
+package conn
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+
+	"go.rtnl.ai/x/dsn"
+)
+
+func openSQLite3(_ context.Context, uri *dsn.DSN) (*sql.DB, error) {
+	db, err := sql.Open("sqlite3", uri.Path)
+	if err != nil {
+		return nil, errors.Join(ErrConnect, err)
+	}
+	return db, nil
+}

--- a/conn/sqlite_test.go
+++ b/conn/sqlite_test.go
@@ -1,0 +1,19 @@
+package conn_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"go.rtnl.ai/tidal/suite"
+)
+
+func TestSQLite3(t *testing.T) {
+	s := &connSuite{}
+	s.Provider = &suite.SQLiteProvider{}
+	s.Teardown = suite.TeardownNone
+
+	_, err := s.ResolveDSN("")
+	require.NoError(t, err, "could not resolve sqlite DSN")
+
+	suite.Run(t, s)
+}

--- a/conn/sqlite_test.go
+++ b/conn/sqlite_test.go
@@ -2,6 +2,7 @@ package conn_test
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 	"go.rtnl.ai/tidal/suite"
@@ -16,4 +17,25 @@ func TestSQLite3(t *testing.T) {
 	require.NoError(t, err, "could not resolve sqlite DSN")
 
 	suite.Run(t, s)
+}
+
+// TestDatetimeReturnsUTC tests that SQLite datetime values are returned as UTC.
+func (s *connSuite) TestDatetimeReturnsUTC() {
+	s.requireSQLite3()
+	require := s.Require()
+	ctx := s.Context()
+
+	_, err := s.DB.ExecContext(ctx, "CREATE TEMP TABLE conn_ts_test (ts DATETIME NOT NULL)")
+	require.NoError(err)
+
+	want := time.Date(2025, 2, 14, 11, 21, 42, 0, time.UTC)
+	_, err = s.DB.ExecContext(ctx, "INSERT INTO conn_ts_test (ts) VALUES (?)", want)
+	require.NoError(err)
+
+	var got time.Time
+	err = s.DB.QueryRowContext(ctx, "SELECT ts FROM conn_ts_test").Scan(&got)
+	require.NoError(err)
+	require.Equal(time.UTC, got.Location())
+	// SQLite datetime storage is second precision in practice; compare at that granularity.
+	require.True(want.Truncate(time.Second).Equal(got.Truncate(time.Second)))
 }


### PR DESCRIPTION
### Scope of changes

Postgres connections will set options for the Go pgx library to return UTC times, much like lib/pq did by default. A TODO was added to handle that as a user-facing option in the future. Added a README section detailing connection options available from tidal.Open and refactored that function to have provider-specific opening functions. Added a test to ensure no regressions.

### Estimated PR Size:

- [ ] Tiny
- [x] Small
- [ ] Medium
- [ ] Large
- [ ] Huge

### Acceptance criteria

This PR will be merged without review.

<!--
[Describe how reviewers can test this change to be sure that it works correctly or copy the requirements from the Shortcut story. Add a checklist below if possible.]
-->

### Author checklist

- [x] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ] I have updated the dependencies list
- [x] I have added new test fixtures as needed to support added tests
- [x] I have added or updated the documentation
- [ ] I have run go generate to update generated code
<!--
- [ ] Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.
- [ ] To the best of my ability, I believe that this PR represents a good solution to the specified problem and that it should be merged into the main code base.
-->