### PR TITLE
[FIX] SQLite FK processing when truncating/dropping suite dbs

### DIFF
--- a/fields/fields_test.go
+++ b/fields/fields_test.go
@@ -38,4 +38,3 @@ func TestPostgresFields(t *testing.T) {
 	// Run the tests
 	suite.Run(t, s)
 }
-

--- a/suite/sqlite.go
+++ b/suite/sqlite.go
@@ -222,12 +222,6 @@ func (p *SQLiteProvider) listTables(tx *sql.Tx) (tables []string, err error) {
 	return tables, rows.Err()
 }
 
-func (p *SQLiteProvider) foreignKeysEnabled(tx *sql.Tx) (enabled bool, err error) {
-	row := tx.QueryRow("PRAGMA foreign_keys")
-	err = row.Scan(&enabled)
-	return enabled, err
-}
-
 func (p *SQLiteProvider) foreignKeysEnabledConn(ctx context.Context, conn *sql.Conn) (enabled bool, err error) {
 	row := conn.QueryRowContext(ctx, "PRAGMA foreign_keys")
 	err = row.Scan(&enabled)

--- a/suite/sqlite.go
+++ b/suite/sqlite.go
@@ -92,8 +92,33 @@ func (p *SQLiteProvider) DropDB(ctx context.Context, uri *dsn.DSN) (err error) {
 }
 
 func (p *SQLiteProvider) DropTables(ctx context.Context, conn *tidal.DB) (err error) {
+	var dbc *sql.Conn
+	if dbc, err = conn.DB.Conn(ctx); err != nil {
+		return fmt.Errorf("could not get db connection: %w", err)
+	}
+	defer dbc.Close()
+
+	var fk bool
+	if fk, err = p.foreignKeysEnabledConn(ctx, dbc); err != nil {
+		return fmt.Errorf("could not check foreign keys: %w", err)
+	}
+
+	if fk {
+		// PRAGMA foreign_keys is connection-scoped in SQLite, so this must run on the
+		// same connection used for the transaction below.
+		if _, err = dbc.ExecContext(ctx, "PRAGMA foreign_keys = OFF"); err != nil {
+			return fmt.Errorf("could not set foreign keys to off: %w", err)
+		}
+
+		defer func() {
+			if _, fkerr := dbc.ExecContext(ctx, "PRAGMA foreign_keys = ON"); fkerr != nil {
+				err = errors.Join(err, fmt.Errorf("could not set foreign keys to on: %w", fkerr))
+			}
+		}()
+	}
+
 	var tx *sql.Tx
-	if tx, err = conn.DB.BeginTx(ctx, &sql.TxOptions{ReadOnly: false, Isolation: sql.LevelSerializable}); err != nil {
+	if tx, err = dbc.BeginTx(ctx, &sql.TxOptions{ReadOnly: false, Isolation: sql.LevelSerializable}); err != nil {
 		return fmt.Errorf("could not begin transaction: %w", err)
 	}
 	defer tx.Rollback()
@@ -101,19 +126,6 @@ func (p *SQLiteProvider) DropTables(ctx context.Context, conn *tidal.DB) (err er
 	var tables []string
 	if tables, err = p.listTables(tx); err != nil {
 		return fmt.Errorf("could not list tables: %w", err)
-	}
-
-	// Disable foreign key constraints.
-	var fk bool
-	if fk, err = p.foreignKeysEnabled(tx); err != nil {
-		return fmt.Errorf("could not check foreign keys: %w", err)
-	}
-
-	if fk {
-		// Temporarily disable foreign key constraints.
-		if _, err = tx.Exec("PRAGMA foreign_keys = OFF"); err != nil {
-			return fmt.Errorf("could not set foreign keys to off: %w", err)
-		}
 	}
 
 	for _, table := range tables {
@@ -122,19 +134,37 @@ func (p *SQLiteProvider) DropTables(ctx context.Context, conn *tidal.DB) (err er
 		}
 	}
 
-	if fk {
-		// Re-enable foreign key constraints.
-		if _, err = tx.Exec("PRAGMA foreign_keys = ON"); err != nil {
-			return fmt.Errorf("could not set foreign keys to on: %w", err)
-		}
-	}
-
 	return tx.Commit()
 }
 
 func (p *SQLiteProvider) TruncateTables(ctx context.Context, conn *tidal.DB) (err error) {
+	var dbc *sql.Conn
+	if dbc, err = conn.DB.Conn(ctx); err != nil {
+		return fmt.Errorf("could not get db connection: %w", err)
+	}
+	defer dbc.Close()
+
+	var fk bool
+	if fk, err = p.foreignKeysEnabledConn(ctx, dbc); err != nil {
+		return fmt.Errorf("could not check foreign keys: %w", err)
+	}
+
+	if fk {
+		// PRAGMA foreign_keys is connection-scoped in SQLite, so this must run on the
+		// same connection used for the transaction below.
+		if _, err = dbc.ExecContext(ctx, "PRAGMA foreign_keys = OFF"); err != nil {
+			return fmt.Errorf("could not set foreign keys to off: %w", err)
+		}
+
+		defer func() {
+			if _, fkerr := dbc.ExecContext(ctx, "PRAGMA foreign_keys = ON"); fkerr != nil {
+				err = errors.Join(err, fmt.Errorf("could not set foreign keys to on: %w", fkerr))
+			}
+		}()
+	}
+
 	var tx *sql.Tx
-	if tx, err = conn.DB.BeginTx(ctx, &sql.TxOptions{ReadOnly: false, Isolation: sql.LevelSerializable}); err != nil {
+	if tx, err = dbc.BeginTx(ctx, &sql.TxOptions{ReadOnly: false, Isolation: sql.LevelSerializable}); err != nil {
 		return fmt.Errorf("could not begin transaction: %w", err)
 	}
 	defer tx.Rollback()
@@ -142,19 +172,6 @@ func (p *SQLiteProvider) TruncateTables(ctx context.Context, conn *tidal.DB) (er
 	var tables []string
 	if tables, err = p.listTables(tx); err != nil {
 		return fmt.Errorf("could not list tables: %w", err)
-	}
-
-	// Disable foreign key constraints.
-	var fk bool
-	if fk, err = p.foreignKeysEnabled(tx); err != nil {
-		return fmt.Errorf("could not check foreign keys: %w", err)
-	}
-
-	if fk {
-		// Temporarily disable foreign key constraints.
-		if _, err = tx.Exec("PRAGMA foreign_keys = OFF"); err != nil {
-			return fmt.Errorf("could not set foreign keys to off: %w", err)
-		}
 	}
 
 	for _, table := range tables {
@@ -169,13 +186,6 @@ func (p *SQLiteProvider) TruncateTables(ctx context.Context, conn *tidal.DB) (er
 			if !strings.Contains(err.Error(), "no such table: sqlite_sequence") {
 				return fmt.Errorf("could not restart auto-increment counter for table %s: %w", table, err)
 			}
-		}
-	}
-
-	if fk {
-		// Re-enable foreign key constraints.
-		if _, err = tx.Exec("PRAGMA foreign_keys = ON"); err != nil {
-			return fmt.Errorf("could not set foreign keys to on: %w", err)
 		}
 	}
 
@@ -214,6 +224,12 @@ func (p *SQLiteProvider) listTables(tx *sql.Tx) (tables []string, err error) {
 
 func (p *SQLiteProvider) foreignKeysEnabled(tx *sql.Tx) (enabled bool, err error) {
 	row := tx.QueryRow("PRAGMA foreign_keys")
+	err = row.Scan(&enabled)
+	return enabled, err
+}
+
+func (p *SQLiteProvider) foreignKeysEnabledConn(ctx context.Context, conn *sql.Conn) (enabled bool, err error) {
+	row := conn.QueryRowContext(ctx, "PRAGMA foreign_keys")
 	err = row.Scan(&enabled)
 	return enabled, err
 }


### PR DESCRIPTION
### Scope of changes

For sqlite to truncate or drop db tables when working on a FK-enabled db, we need to stop processing FKs first on the related connection.

### Estimated PR Size:

- [x] Tiny
- [ ] Small
- [ ] Medium
- [ ] Large
- [ ] Huge

### Acceptance criteria

This PR will be merged without review.

<!--
[Describe how reviewers can test this change to be sure that it works correctly or copy the requirements from the Shortcut story. Add a checklist below if possible.]
-->

### Author checklist

- [x] I have manually tested the change and/or added automation in the form of unit tests or integration tests
- [ ] I have updated the dependencies list
- [ ] I have added new test fixtures as needed to support added tests
- [ ] I have added or updated the documentation
- [ ] I have run go generate to update generated code
<!--
- [ ] Check this box if a reviewer can merge this pull request after approval (leave it unchecked if you want to do it yourself)

### Reviewer(s) checklist

- [ ] Any new user-facing content that has been added for this PR has been QA'ed to ensure correct grammar, spelling, and understandability.
- [ ] To the best of my ability, I believe that this PR represents a good solution to the specified problem and that it should be merged into the main code base.
-->